### PR TITLE
Clarify Extensions in Ops Table

### DIFF
--- a/vector-op-types.csv
+++ b/vector-op-types.csv
@@ -1,50 +1,50 @@
 Base/Vtypes,Mnemonic,Category,V operands,G operands,Description,Src Type,Dst Type (dst_width = src_width),Dst Type (dst_width = 2*src_width),Dst Type (dst_width = src_width / 2),"Dst Vector/Scalar Behavior: vector src,  scalar dst (instruction mask bits = 00, or scalar shape when vtypes is enabled)","Dst Scalar/Vector Behavior: vector dst,  scalar src (src was written previously as a scalar using 00 mask bits)"
 Vtypes,VADD,arith,2,0,add,"S/U,F","S/U,F",S/U,ILLEGAL,Reduction,Splat
 Base,VADD.X,arith,2,0,add,S/U,S/U,ILLEGAL,ILLEGAL,First Element,Splat
-Base,"VFADD.[H,S,D]",arith,2,0,add,F,F,ILLEGAL,ILLEGAL,First Element,Splat
+"Base + [F,D]","VFADD.[H,S,D]",arith,2,0,add,F,F,ILLEGAL,ILLEGAL,First Element,Splat
 Vtypes,VADDI,arith,1,0,add immediate,S/U,S/U,S/U,ILLEGAL,Reduction,Splat
 Base,VADDI.X,arith,1,0,add immediate,S/U,S/U,ILLEGAL,ILLEGAL,First Element,Splat
 Base,VPOPC,arith,1,0,count bits set,I,I,ILLEGAL,ILLEGAL,First Element,Splat
 Vtypes,VSUB,arith,2,0,subtract,"S/U,F","S/U,F",S/U,ILLEGAL,First Element,Splat
 Base,VSUB.X,arith,2,0,subtract,I,I,ILLEGAL,ILLEGAL,First Element,Splat
-Base,"VFSUB.[H,S,D]",arith,2,0,subtract,F,F,ILLEGAL,ILLEGAL,First Element,Splat
+"Base + [F,D]","VFSUB.[H,S,D]",arith,2,0,subtract,F,F,ILLEGAL,ILLEGAL,First Element,Splat
 Vtypes,VSEQ,compare,2,0,"1 if ==, else 0","S/U,F",ן,I,ILLEGAL,First Element,Splat
 Base,VSEQ.X,compare,2,0,"1 if ==, else 0",S/U,I,I,ILLEGAL,First Element,Splat
-Base,VFEQ.[H.S.D],compare,2,0,"1 if ==, else 0",F,I,I,ILLEGAL,First Element,Splat
+"Base + [F,D]",VFEQ.[H.S.D],compare,2,0,"1 if ==, else 0",F,I,I,ILLEGAL,First Element,Splat
 Vtypes,VSGE,compare,2,0,"1 if >=, else 0","S/U,F",I,I,ILLEGAL,First Element,Splat
 Base,VSGE.X,compare,2,0,"1 if >=, else 0",S/U,I,I,ILLEGAL,First Element,Splat
-Base,"VFLE.[H,S,D]",compare,2,0,"1 if <=, else 0",F,I,I,ILLEGAL,First Element,Splat
+"Base + [F,D]","VFLE.[H,S,D]",compare,2,0,"1 if <=, else 0",F,I,I,ILLEGAL,First Element,Splat
 Vtypes,VSLT,compare,2,0,"1 if <, else 0","S/U,F",ן,I,ILLEGAL,First Element,Splat
 Base,VSLT.X,compare,2,0,"1 if <, else 0",S/U,ן,I,ILLEGAL,First Element,Splat
-Base,"VFLT.[H,S,D]",compare,2,0,"1 if <, else 0",F,ן,I,ILLEGAL,First Element,Splat
+"Base + [F,D]","VFLT.[H,S,D]",compare,2,0,"1 if <, else 0",F,ן,I,ILLEGAL,First Element,Splat
 Vtypes,VSNE,compare,2,0,"1 if <>, else 0","S/U,F",ן,I,ILLEGAL,First Element,Splat
 Base,VSNE.X,compare,2,0,"1 if <>, else 0",S/U,ן,I,ILLEGAL,First Element,Splat
-Base,"VFNE.[H,S,D]",compare,2,0,"1 if <>, else 0",F,ן,I,ILLEGAL,First Element,Splat
+"Base + [F,D]","VFNE.[H,S,D]",compare,2,0,"1 if <>, else 0",F,ן,I,ILLEGAL,First Element,Splat
 Vtypes,VCVT,convert,1,1,convert type,"S/U,F","F,S/U",ILLEGAL,ILLEGAL,First Element,Splat
-Base,"VFCVT.[X,H,S,D].[X,H,S,D]",convert,1,1,convert type,"S/U,F","F,S/U",ILLEGAL,ILLEGAL,First Element,Splat
+"Base + [F,D]","VFCVT.[X,H,S,D].[X,H,S,D]",convert,1,1,convert type,"S/U,F","F,S/U",ILLEGAL,ILLEGAL,First Element,Splat
 Vtypes,VSGNJ,copy/sign,2,0,FP sign injection,F,F,ILLEGAL,ILLEGAL,First Element,Splat
-Base,"VFSGNJ.[H,S,D]",copy/sign,2,0,FP sign injection,F,F,ILLEGAL,ILLEGAL,First Element,Splat
+"Base + [F,D]","VFSGNJ.[H,S,D]",copy/sign,2,0,FP sign injection,F,F,ILLEGAL,ILLEGAL,First Element,Splat
 Vtypes,VSGNJN,copy/sign,2,0,FP inverted sign injection,F,F,ILLEGAL,ILLEGAL,First Element,Splat
-Base,"VFSGNJN.[H,S,D]",copy/sign,2,0,FP inverted sign injection,F,F,ILLEGAL,ILLEGAL,First Element,Splat
+"Base + [F,D]","VFSGNJN.[H,S,D]",copy/sign,2,0,FP inverted sign injection,F,F,ILLEGAL,ILLEGAL,First Element,Splat
 Vtypes,VSGNJX,copy/sign,2,0,FP xor sign,F,F,ILLEGAL,ILLEGAL,First Element,Splat
-Base,"VFSGNJX.[H,S,D]",copy/sign,2,0,FP xor sign,F,F,ILLEGAL,ILLEGAL,First Element,Splat
-Vtypes,VDIV,divsqrt,2,0,divide,F,F,ILLEGAL,ILLEGAL,First Element,Splat
-Base,"VFDIV[H,S,D]",divsqrt,2,0,divide,F,F,ILLEGAL,ILLEGAL,First Element,Splat
-Vtypes,VREM,divsqrt,2,0,partial remainder,F,F,ILLEGAL,ILLEGAL,First Element,Splat
-Base,"VFREM.[H,S,D]",divsqrt,2,0,partial remainder,F,F,ILLEGAL,ILLEGAL,First Element,Splat
-Vtypes,VSQRT,divsqrt,1,0,square root,F,F,ILLEGAL,ILLEGAL,First Element,Splat
-Base,"VFSQRT.[H,S,D]",divsqrt,1,0,square root,F,F,ILLEGAL,ILLEGAL,First Element,Splat
+"Base + [F,D]","VFSGNJX.[H,S,D]",copy/sign,2,0,FP xor sign,F,F,ILLEGAL,ILLEGAL,First Element,Splat
+Vtypes + M,VDIV,divsqrt,2,0,divide,F,F,ILLEGAL,ILLEGAL,First Element,Splat
+"Base + M + [F,D]","VFDIV[H,S,D]",divsqrt,2,0,divide,F,F,ILLEGAL,ILLEGAL,First Element,Splat
+Vtypes + M,VREM,divsqrt,2,0,partial remainder,F,F,ILLEGAL,ILLEGAL,First Element,Splat
+"Base + M + [F,D]","VFREM.[H,S,D]",divsqrt,2,0,partial remainder,F,F,ILLEGAL,ILLEGAL,First Element,Splat
+Vtypes + M,VSQRT,divsqrt,1,0,square root,F,F,ILLEGAL,ILLEGAL,First Element,Splat
+"Base + M + [F,D]","VFSQRT.[H,S,D]",divsqrt,1,0,square root,F,F,ILLEGAL,ILLEGAL,First Element,Splat
 Vtypes,VCLASS,identify FP,1,0,"FP value class (e.g., 0, inf)",F,F,ILLEGAL,ILLEGAL,First Element,Splat
-Base,"VFCLASS.[H,S,D]",identify FP,1,0,"FP value class (e.g., 0, inf)",F,F,ILLEGAL,ILLEGAL,First Element,Splat
+"Base + [F,D]","VFCLASS.[H,S,D]",identify FP,1,0,"FP value class (e.g., 0, inf)",F,F,ILLEGAL,ILLEGAL,First Element,Splat
 Vtypes,VL,load,0,1,load vector (unit stride),I,B/F,ILLEGAL,ILLEGAL,First Element,Splat
 Base,"VL.[B,H,W,D][U]",load,0,1,load vector (unit stride),I,B,ILLEGAL,ILLEGAL,First Element,Splat
-Base,"VFL.[H,S,D]",load,0,1,load vector (unit stride),I,F,ILLEGAL,ILLEGAL,First Element,Splat
+"Base + [F,D]","VFL.[H,S,D]",load,0,1,load vector (unit stride),I,F,ILLEGAL,ILLEGAL,First Element,Splat
 Vtypes,VLS,load,0,2,load vector (stride),I,B/F,ILLEGAL,ILLEGAL,First Element,Splat
 Base,"VLS.[B,H,W,D][U]",load,0,2,load vector (stride),I,B,ILLEGAL,ILLEGAL,First Element,Splat
-Base,"VFLS.[H,S,D]",load,0,2,load vector (stride),I,F,ILLEGAL,ILLEGAL,First Element,Splat
+"Base + [F,D]","VFLS.[H,S,D]",load,0,2,load vector (stride),I,F,ILLEGAL,ILLEGAL,First Element,Splat
 Vtypes,VLX,load,1,1,load vector indexed (gather),I,B/F,ILLEGAL,ILLEGAL,First Element,Splat
 Base,"VLX.[B,H,W,D][U]",load,1,1,load vector indexed (gather),I,B,ILLEGAL,ILLEGAL,First Element,Splat
-Base,"VFLX.[H,S,D]",load,1,1,load vector indexed (gather),I,F,ILLEGAL,ILLEGAL,First Element,Splat
+"Base + [F,D]","VFLX.[H,S,D]",load,1,1,load vector indexed (gather),I,F,ILLEGAL,ILLEGAL,First Element,Splat
 Vtypes,VLO,load,0,1,load vector ordered,I,B/F,ILLEGAL,ILLEGAL,First Element,Splat
 Base,VAND,logical,2,0,bitwise AND,B,B,ILLEGAL,ILLEGAL,Reduction,Splat
 Base,VANDI,logical,1,0,bitwise AND with immediate,B,B,ILLEGAL,ILLEGAL,Reduction,Splat
@@ -54,17 +54,17 @@ Base,VXOR,logical,2,0,bitwise XOR,B,B,ILLEGAL,ILLEGAL,Reduction,Splat
 Base,VXORI,logical,1,0,bitwise XOR with immediate,B,B,ILLEGAL,ILLEGAL,Reduction,Splat
 Base,VMFIRST,mask,1,0,index of first TRUE lab -> GPR,B,B,ILLEGAL,ILLEGAL,GPR,Splat
 Base,VMPOP,mask,1,0,Count lsb of elements -> GPR,B,B,ILLEGAL,ILLEGAL,GPR,Splat
-Vtypes,VMADD,multiply-add,3,0,Multiply add,"S/U,F","S/U,F","I,F",ILLEGAL,Reduction,Splat
-Base,"VFMADD.[H,S,D]",multiply-add,3,0,Multiply add,F,F,F,ILLEGAL,First Element,Splat
-Vtypes,VMSUB,multiply-add,3,0,Multiply subtract,"S/U,F","S/U,F","I,F",ILLEGAL,Reduction,Splat
-Base,"VFMSUB.[H,S,D]",multiply-add,3,0,Multiply subtract,F,F,F,ILLEGAL,First Element,Splat
-Vtypes,VMUL,multiply-add,2,0,Multiply,"S/U,F","S/U,F","S/U,F",ILLEGAL,Reduction,Splat
-Base,VMUL.X,multiply-add,2,0,Multiply,S/U,S/U,ILLEGAL,ILLEGAL,First Element,Splat
-Base,"VFMUL.[H,S,D]",multiply-add,2,0,Multiply,F,F,ILLEGAL,ILLEGAL,First Element,Splat
-Vtypes,VMULH,multiply-add,2,0,Multiply - return high half,S/U,S/U,ILLEGAL,S/U,Reduction,Splat
-Base,VMULH.X,multiply-add,2,0,Multiply - return high half,S/U,S/U,ILLEGAL,S/U,First Element,Splat
-Vtypes,VNMADD,multiply-add,3,0,negated multiply add,"S/U,F","S/U,F","S/U,F",ILLEGAL,Reduction,Splat
-Vtypes,VNMSUB,multiply-add,3,0,negated multiply sub,"S/U,F","S/U,F","S/U,F",ILLEGAL,ILLEGAL,Splat
+Vtypes + M,VMADD,multiply-add,3,0,Multiply add,"S/U,F","S/U,F","I,F",ILLEGAL,Reduction,Splat
+"Base + M + [F,D]","VFMADD.[H,S,D]",multiply-add,3,0,Multiply add,F,F,F,ILLEGAL,First Element,Splat
+Vtypes + M,VMSUB,multiply-add,3,0,Multiply subtract,"S/U,F","S/U,F","I,F",ILLEGAL,Reduction,Splat
+"Base + M + [F,D]","VFMSUB.[H,S,D]",multiply-add,3,0,Multiply subtract,F,F,F,ILLEGAL,First Element,Splat
+Vtypes + M,VMUL,multiply-add,2,0,Multiply,"S/U,F","S/U,F","S/U,F",ILLEGAL,Reduction,Splat
+Base + M,VMUL.X,multiply-add,2,0,Multiply,S/U,S/U,ILLEGAL,ILLEGAL,First Element,Splat
+"Base + M + [F,D]","VFMUL.[H,S,D]",multiply-add,2,0,Multiply,F,F,ILLEGAL,ILLEGAL,First Element,Splat
+Vtypes + M,VMULH,multiply-add,2,0,Multiply - return high half,S/U,S/U,ILLEGAL,S/U,Reduction,Splat
+Base + M,VMULH.X,multiply-add,2,0,Multiply - return high half,S/U,S/U,ILLEGAL,S/U,First Element,Splat
+Vtypes + M,VNMADD,multiply-add,3,0,negated multiply add,"S/U,F","S/U,F","S/U,F",ILLEGAL,Reduction,Splat
+Vtypes + M,VNMSUB,multiply-add,3,0,negated multiply sub,"S/U,F","S/U,F","S/U,F",ILLEGAL,ILLEGAL,Splat
 Base,VEXTRACT,permute,1,1,extract element -> GPR,B,B,ILLEGAL,ILLEGAL,GPR,N/A
 Base,VINSERT,permute,1,1,insert element(s),B,B,ILLEGAL,ILLEGAL,First Element,Placement
 Base,VMERGE,permute,2,0,merge registers,B,B,ILLEGAL,ILLEGAL,First Element,Splat
@@ -75,10 +75,10 @@ Base,VCLIP,round,1,1,clip to narrow,S/U,S/U,ILLEGAL,S/U,First Element,Splat
 Base,VCLIPI,round,1,0,"Clip, shift by imm",S/U,S/U,ILLEGAL,S/U,First Element,Splat
 Vtypes,VMAX,select,2,0,return max element,"S/U,F","S/U,F",ILLEGAL,ILLEGAL,Reduction,Splat
 Base,VMAX.X,select,2,0,return max element,S/U,S/U,ILLEGAL,ILLEGAL,First Element,Splat
-Base,"VFMAX.[H,S,D]",select,2,0,return max element,F,F,ILLEGAL,ILLEGAL,First Element,Splat
+"Base + [F,D]","VFMAX.[H,S,D]",select,2,0,return max element,F,F,ILLEGAL,ILLEGAL,First Element,Splat
 Vtypes,VMIN,select,2,0,return min element,"S/U,F","S/U,F",ILLEGAL,ILLEGAL,Reduction,Splat
 Base,VMIN.X,select,2,0,return min element,S/U,S/U,ILLEGAL,ILLEGAL,First Element,Splat
-Base,"VFMIN.[H,S,D]",select,2,0,return min element,F,F,ILLEGAL,ILLEGAL,First Element,Splat
+"Base + [F,D]","VFMIN.[H,S,D]",select,2,0,return min element,F,F,ILLEGAL,ILLEGAL,First Element,Splat
 Base,VSL,shift,2,0,Shift Left,I,B,ILLEGAL,ILLEGAL,First Element,Splat
 Base,VSLI,shift,1,0,shift left by immediate,I,B,ILLEGAL,ILLEGAL,First Element,Splat
 Base,VSR,shift,2,0,Shift Right (arithmetic),I,B,ILLEGAL,ILLEGAL,First Element,Splat
@@ -90,10 +90,10 @@ Base,"VSS.[B,H,W,D][U]",store,0,2,store vector (stride),I,B,ILLEGAL,ILLEGAL,Writ
 Vtypes,VSX,store,1,1,store vector indexed (scatter),I,"B,F",ILLEGAL,ILLEGAL,First Element,Write a single value
 Base,"VSX.[B,H,W,D][U]",store,1,1,store vector indexed (scatter),I,B,ILLEGAL,ILLEGAL,Write First Element,Splat
 Vtypes,VSO,store,0,1,store vector ordered,I,"B,F",ILLEGAL,ILLEGAL,First Element,Write a single value
-Vtypes,VAMOADD,xAtomic:arith,2,0,Atomic: VAdd,S/U,S/U,ILLEGAL,ILLEGAL,Reduction,ILLEGAL
-Vtypes,VAMOAND,xAtomic:logical,2,0,Atomic: AND,B,B,ILLEGAL,ILLEGAL,Reduction,ILLEGAL
-Vtypes,VAMOOR,xAtomic:logical,2,0,Atomic: OR,B,B,ILLEGAL,ILLEGAL,Reduction,ILLEGAL
-Vtypes,VAMOXOR,xAtomic:logical,2,0,Atomic: XOR,B,B,ILLEGAL,ILLEGAL,Reduction,ILLEGAL
-Vtypes,VAMOMAX,xAtomic:select,2,0,Atomic: Vmax,S/U,S/U,ILLEGAL,ILLEGAL,Reduction,ILLEGAL
-Vtypes,VAMOMIN,xAtomic:select,2,0,Atomic: VMin,S/U,S/U,ILLEGAL,ILLEGAL,Reduction,ILLEGAL
-Vtypes,VAMOSWAP,xAtomic:swap,2,0,Atomic: VSwap,B,B,ILLEGAL,ILLEGAL,First Element,ILLEGAL
+Vtypes + A,VAMOADD,xAtomic:arith,2,0,Atomic: VAdd,S/U,S/U,ILLEGAL,ILLEGAL,Reduction,ILLEGAL
+Vtypes + A,VAMOAND,xAtomic:logical,2,0,Atomic: AND,B,B,ILLEGAL,ILLEGAL,Reduction,ILLEGAL
+Vtypes + A,VAMOOR,xAtomic:logical,2,0,Atomic: OR,B,B,ILLEGAL,ILLEGAL,Reduction,ILLEGAL
+Vtypes + A,VAMOXOR,xAtomic:logical,2,0,Atomic: XOR,B,B,ILLEGAL,ILLEGAL,Reduction,ILLEGAL
+Vtypes + A,VAMOMAX,xAtomic:select,2,0,Atomic: Vmax,S/U,S/U,ILLEGAL,ILLEGAL,Reduction,ILLEGAL
+Vtypes + A,VAMOMIN,xAtomic:select,2,0,Atomic: VMin,S/U,S/U,ILLEGAL,ILLEGAL,Reduction,ILLEGAL
+Vtypes + A,VAMOSWAP,xAtomic:swap,2,0,Atomic: VSwap,B,B,ILLEGAL,ILLEGAL,First Element,ILLEGAL


### PR DESCRIPTION
In reference to issue #24
Clarify required extensions for particular ops in the Base 
(No clarifications for VTypes type-related extensions, only op-related extensions)