### PR TITLE
Add Destructive Integer Multiply-Add

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -942,6 +942,18 @@ operate on `vsew` source and destination widths.
     vremu           vd, vs1, vs2, vm
 ----
 
+==== Integer Multiply Add
+The integer fused multiply-add is a destructive operation in order to save
+encoding space. The two source operands `vs1`, `vs2` are multiplied 
+element-wise, and the result is accumulated into `vd`.
+
+[source,asm]
+----
+    vmadd           vd, vs1, vs2, vm
+    vmaddu          vd, vs1, vs2, vm
+----
+
+
 === Integer Reduction Operations
 These instructions take a vector shape as input and produce a scalar
 shape.

--- a/vector-op-base.csv
+++ b/vector-op-base.csv
@@ -38,6 +38,7 @@ VXOR,logical,2,0,bitwise XOR,B,B,ILLEGAL,ILLEGAL,Reduction
 VXORI,logical,1,0,bitwise XOR with immediate,B,B,ILLEGAL,ILLEGAL,Reduction
 VMFIRST,mask,1,0,index of first TRUE lab -> GPR,B,B,ILLEGAL,ILLEGAL,GPR
 VMPOP,mask,1,0,Count lsb of elements -> GPR,B,B,ILLEGAL,ILLEGAL,GPR
+"VMADD.X[U]",multiply-add,2,0,Destructive multiply add,S/U,S/U,S/U,ILLEGAL,First Element
 "VFMADD.[H,S,D]",multiply-add,3,0,Multiply add,F,F,F,ILLEGAL,First Element
 "VFMSUB.[H,S,D]",multiply-add,3,0,Multiply subtract,F,F,F,ILLEGAL,First Element
 VMUL.X[U],multiply-add,2,0,Multiply,S/U,S/U,ILLEGAL,ILLEGAL,First Element


### PR DESCRIPTION
This add a destructive integer multiply-add to the spec and the op-types table.
It still needs to be added to encoding table.