### PR TITLE
Delete vins.v.x instruction reference.

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -3673,7 +3673,7 @@ implementations.
 
 [source]
 ----
-vmv.s.x vd, rs1  # vd[0] = rs1, vins.v.x vd, x0, rs1
+vmv.s.x vd, rs1  # vd[0] = rs1
 ----
 
 The `vmv.s.x` instruction copies the scalar integer register to


### PR DESCRIPTION
We don't have a vins.v.x instruction, so we can't use it to document the
behavior of vmv.s.x.