### PR TITLE
Fix compares, changing lte to le and gte to ge.

### DIFF
--- a/inst-table.adoc
+++ b/inst-table.adoc
@@ -34,13 +34,13 @@ funct6                funct6                funct6
 010110                010110 V  VMUNARY0    010110
 010111 VXI vmerge     010111 V  vcompress   010111  F vfmerge.vf
 011000 VXI vseq       011000 V  vmandnot    011000 VF vfeq
-011001 VXI vsne       011001 V  vmand       011001 VF vflte
+011001 VXI vsne       011001 V  vmand       011001 VF vfle
 011010 VX  vsltu      011010 V  vmor        011010 VF vford
 011011 VX  vslt       011011 V  vmxor       011011 VF vflt
 011100 VXI vsleu      011100 V  vmornot     011100 VF vfne
 011101 VXI vsle       011101 V  vmnand      011101  F vfgt
 011110  XI vsgtu      011110 V  vmnor       011110
-011111  XI vsgt       011111 V  vmxnor      011111  F vfgte
+011111  XI vsgt       011111 V  vmxnor      011111  F vfge
 
 100000 VXI vsaddu     100000 VX vdivu       100000 VF vfdiv   
 100001 VXI vsadd      100001 VX vdiv        100001  F vfrdiv  
@@ -202,8 +202,8 @@ VMUNARY0 encoding space
 
 ////
 
-X  vsgteu
-  X  vsgte
+X  vsgeu
+  X  vsge
 
 
 vx4muladd

--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -2924,28 +2924,28 @@ floating-point compare instructions.
     vflt.vf vd, vs2, rs1, vm   # vector-scalar
 
     # Compare less than or equal
-    vflte.vv vd, vs2, vs1, vm   # Vector-vector
-    vflte.vf vd, vs2, rs1, vm   # vector-scalar
+    vfle.vv vd, vs2, vs1, vm   # Vector-vector
+    vfle.vf vd, vs2, rs1, vm   # vector-scalar
 
     # Compare greater than
     vfgt.vf vd, vs2, rs1, vm   # vector-scalar
 
     # Compare greater than or equal
-    vfgte.vf vd, vs2, rs1, vm   # vector-scalar
+    vfge.vf vd, vs2, rs1, vm   # vector-scalar
 ----
 
 ----
 Comparison      Assembler Mapping             Assembler pseudoinstruction
 
 va < vb         vflt.vv vd, va, vb, vm
-va <= vb        vflte.vv vd, va, vb, vm
+va <= vb        vfle.vv vd, va, vb, vm
 va > vb         vflt.vv vd, vb, va, vm     vfgt.vv vd, va, vb, vm
-va >= vb        vflte.vv vd, vb, va, vm    vfgte.vv vd, va, vb, vm
+va >= vb        vfle.vv vd, vb, va, vm    vfge.vv vd, va, vb, vm
 
 va < f          vflt.vf vd, va, f, vm
-va <= f         vflte.vf vd, va, f, vm
+va <= f         vfle.vf vd, va, f, vm
 va > f          vfgt.vf vd, va, f, vm
-va >= f         vfgte.vf vd, va, f, vm
+va >= f         vfge.vf vd, va, f, vm
 
 va, vb vector register groups
 f      scalar floating-point register


### PR DESCRIPTION
The vector integer compares were fixed earlier, but the vector float compares were missed.  I also found two missed vector integer compare references in comments.
