### PR TITLE
Disallow rd = v0 for vadc/vsbc

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -2105,6 +2105,9 @@ function to support long word arithmetic for subtraction.
 The encodings corresponding to the masked versions (vm=0) of `vadc`
 and `vsbc` are reserved.
 
+For both `vadc` and `vsbc`, an illegal instruction exception is raised if the
+destination vector register is `v0`.
+
 === Vector Bitwise Logical Instructions
 
 ----


### PR DESCRIPTION
These instructions implicitly write the carry-out into v0.  So if rd = v0,
there is a WAW hazard within the instruction itself.  Rather than making the
behavior well defined, which could be annoying to implement for some
microarchitectures but provides little benefit to software, I propose we make
the instructions illegal in this case.