### PR TITLE
Unify vl=0 and vstart >= vl rules

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -130,9 +130,9 @@ the destination vector undisturbed, and to reset the `vstart` CSR to
 zero at the end of execution.
 
 If the value in the `vstart` register is greater than or equal to the
-vector length `vl` then no element operations are performed, though
-elements at the end of the destination vector past `vl` are zeroed,
-and the `vstart` register is reset to zero.
+vector length `vl` then no element operations are performed, nor are the
+elements at the end of the destination vector past `vl` are zeroed.  The
+`vstart` register is then reset to zero.
 
 The `vstart` CSR is defined to have only enough writeable bits to hold
 the largest element index (one less than the maximum VLMAX) or
@@ -339,8 +339,11 @@ instruction variants.
 The `vl` register holds an unsigned integer specifying the number of
 elements to be updated by a vector instruction.  Elements in the
 destination vector with indices {ge} `vl` are zeroed during
-execution of a vector instruction.  As a special case, when `vl`=0,
+execution of a vector instruction.  When `vstart` {ge} `vl`,
 no elements are updated in the destination vector.
+
+NOTE: As a consequence, when `vl`=0, no elements are
+updated inthe destination vector, regardless of `vstart`.
 
 NOTE: The number of bits implemented in `vl` depends on the
 implementation's maximum vector length of the smallest supported


### PR DESCRIPTION
Currently, vl=0 is a special case in the spec: elements past vl are left
intact in this case.  vstart >= vl (when vl > 0) is sort of a special case
itself: no elements below vl are updated, but elements past vl are zeroed.

The proposal is to unfiy these cases, and leave the entire vector intact
when vstart >= vl.  Or, put another way, the elements past vl are zeroed if
and only if some other element in the vector needs to be written.