### PR TITLE
Clarify that mask instructions operate bitwise within a mask element

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -3281,6 +3281,9 @@ Vector mask logical instructions are always unmasked so there are no
 inactive elements.  Mask elements past `vl`, the tail elements, are
 zeroed.
 
+Within a mask element, these instructions perform their operations in
+a bitwise fashion.
+
 ----
     vmand.mm vd, vs2, vs1     # vd =   vs2 &  vs1
     vmnand.mm vd, vs2, vs1    # vd = ~(vs2 &  vs1)


### PR DESCRIPTION
At least, I think it's a clarification, not a change...

Closes #139