### PR TITLE
Replace (vl == 0) with (vstart >= vl) in descriptions of permutations

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -3693,6 +3693,9 @@ VLEN/SEW) are zeroed.
 If `vstart` {ge} `vl`, no operation is performed and the destination
 register is not updated.
 
+NOTE: As a consequence, when `vl`=0, no elements are updated in the
+destination vector register group, regardless of `vstart`.
+
 NOTE: The complementary `vins.v.x` instruction, which allows a write
 to any element in a vector register, has been removed.  This
 instruction would be the only instruction (apart from `vsetvl`) that
@@ -3728,6 +3731,9 @@ elements in the destination vector register ( 0 < index < VLEN/SEW)
 are zeroed.  If `vstart` {ge} `vl`, no operation is performed and
 the destination register is not updated.
 
+NOTE: As a consequence, when `vl`=0, no elements are updated in the
+destination vector register group, regardless of `vstart`.
+
 === Vector Slide Instructions
 
 The slide instructions move elements up and down a vector register
@@ -3742,6 +3748,9 @@ than other offsets.
 For all of the `vslideup`, `vslidedown`, `vslide1up`, and
 `vslide1down` instructions, if `vstart` {ge} `vl`, the instruction performs no
 operation and leaves the destination vector register unchanged.
+
+NOTE: As a consequence, when `vl`=0, no elements are updated in the
+destination vector register group, regardless of `vstart`.
 
 ==== Vector Slideup Instructions
 

--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -3690,8 +3690,8 @@ ignored.  If SEW > XLEN, the value is zero-extended to SEW bits.
 The other elements in the destination vector register ( 0 < index <
 VLEN/SEW) are zeroed.
 
-If `vl`=0, no operation is performed and the destination register is
-not updated.
+If `vstart` {ge} `vl`, no operation is performed and the destination
+register is not updated.
 
 NOTE: The complementary `vins.v.x` instruction, which allows a write
 to any element in a vector register, has been removed.  This
@@ -3725,8 +3725,8 @@ the destination vector register.  If SEW < FLEN, the least-significant
 bits are copied and the upper XLEN-SEW bits are ignored.  If SEW >
 XLEN, the value is NaN-boxed (1-extended) to SEW bits.  The other
 elements in the destination vector register ( 0 < index < VLEN/SEW)
-are zeroed.  If `vl`=0, no operation is performed and the destination
-register is not updated.
+are zeroed.  If `vstart` {ge} `vl`, no operation is performed and
+the destination register is not updated.
 
 === Vector Slide Instructions
 
@@ -3740,7 +3740,7 @@ In particular, power-of-2 offsets may operate substantially faster
 than other offsets.
 
 For all of the `vslideup`, `vslidedown`, `vslide1up`, and
-`vslide1down` instructions, if `vl`=0, the instruction performs no
+`vslide1down` instructions, if `vstart` {ge} `vl`, the instruction performs no
 operation and leaves the destination vector register unchanged.
 
 ==== Vector Slideup Instructions


### PR DESCRIPTION
This is a continuation of #133.