### PR TITLE
Clarify vsbc carry convention

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -2150,6 +2150,9 @@ function to support long word arithmetic for subtraction.
  vsbc.vx   vd, vs2, rs1  # Vector-scalar
 ----
 
+For `vsbc`, the carry is defined to be 1 iff the difference, prior to
+truncation, is negative.
+
 The encodings corresponding to the masked versions (vm=0) of `vadc`
 and `vsbc` are reserved.
 


### PR DESCRIPTION
The existing pseudocode implies that vsbc follows the convention that the carry flag is set if a borrow should occur, but the normative text isn't clear about the polarity.  x86 and SPARC follow this discipline, but ARM and POWER work the other way around.  So we need to be explicit.