### PR TITLE
Add more info for the stride value in vector-strided-segment-load/store.

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -1705,6 +1705,8 @@ Vector strided segment loads and stores move contiguous segments where
 each segment is separated by the byte stride offset given in the `rs2`
 GPR argument.
 
+Note: The stride could be negative.
+
 ----
     # Format
     vlsseg<nf>{b,h,w}.v vd, (rs1), rs2, vm    # Strided signed segment loads


### PR DESCRIPTION
In https://github.com/riscv/riscv-v-spec/issues/172, there is no restriction for the stride value. This pr try to add a note for that.