### PR TITLE
fix 12.12.1. Vector Integer Divide Instructions header level

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -2519,7 +2519,7 @@ vwmsac.vx vd, rs1, vs2, vm    # vd[i] = -(x[rs1] * vs2[i]) + vd[i]
 
 NOTE: There is no signed-unsigned widening multiply-add instruction.
 
-==== Vector Integer Divide Instructions
+=== Vector Integer Divide Instructions
 
 The divide and remainder instructions are equivalent to the RISC-V
 standard scalar integer multiply/divides, with the same results for


### PR DESCRIPTION
It should be level 2 '12.13' but not level 3

Signed-off-by: Chih-Min Chao <chihmin.chao@sifive.com>