### PR TITLE
source register operand missed in vid.v instruction

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -3645,7 +3645,7 @@ The `vid.v` instruction writes each element's index to the
 destination vector register group, from 0 to `vl`-1.
 
 ----
-    vid.v vd, vm  # Write element ID to destination.
+    vid.v vd, vs2, vm  # Write element ID to destination.
 ----
 
 The instruction can be masked.


### PR DESCRIPTION
Add missing vs2 in vid.v example

Signed-off-by: Weiwei Wang <weiwei.wangx@outlook.com>