### PR TITLE
Weaken constraint that vadc/vsbc can't write v0 to exclude LMUL=1

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -2208,7 +2208,10 @@ For `vmsbc`, the carry is defined to be 1 iff the difference, prior to
 truncation, is negative.
 
 For `vadc` and `vsbc`, an illegal instruction exception is raised
-if the destination vector register is `v0`.
+if the destination vector register is `v0` and LMUL > 1.
+
+NOTE: This constraint corresponds to the constraint on masked vector
+operations that overwrite the mask register.
 
 For `vmadc` and `vmsbc`, an illegal instruction exception is raised if
 the destination vector register overlaps a source vector register


### PR DESCRIPTION
We instituted the stronger constraint because the instruction previously wrote v0.  Now, the constraint should match masked vector operations.

Motivation is to simplify decoding by removing a special case.