### PR TITLE
Treat vrgather immediate as unsigned

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -4067,13 +4067,14 @@ then zero is returned for the element value.
 Vector-scalar and vector-immediate forms of the register gather are
 also provided.  These read one element from the source vector at the
 given index, and write this value to the `vl` elements at the start of
-the destination vector register.
+the destination vector register. The immediate is treated as an unsigned
+integer, giving access to elements up to element 31.
 
 NOTE: These forms allow any vector element to be "splatted" to an entire vector.
 
 ----
 vrgather.vx vd, vs2, rs1, vm # vd[i] = (x[rs1] >= VLMAX) ? 0 : vs2[rs1]
-vrgather.vi vd, vs2, imm, vm # vd[i] = (imm >= VLMAX) ? 0 : vs2[imm]
+vrgather.vi vd, vs2, uimm, vm # vd[i] = (uimm >= VLMAX) ? 0 : vs2[uimm]
 ----
 
 For any `vrgather` instruction, the destination vector register group


### PR DESCRIPTION
A literal reading of the current text would imply it should be signed (as that is the default and vrgather's description says nothing to the contrary), but negative immediates are useless on this instruction, as they would (after sign extension) be larger than 2^31 and thus exceed VLMAX on any implementation and just splat a constant 0 into the destination.

FWIW, binutils currently treats it as unsigned.