### PR TITLE
Remove the vmford instruction

### DIFF
--- a/inst-table.adoc
+++ b/inst-table.adoc
@@ -45,7 +45,7 @@
 | 010111 |V|X|I| vmerge/vmv | 010111 |V| | vcompress   | 010111 | |F| vfmerge.vf/vfmv
 | 011000 |V|X|I| vmseq      | 011000 |V| | vmandnot    | 011000 |V|F| vmfeq
 | 011001 |V|X|I| vmsne      | 011001 |V| | vmand       | 011001 |V|F| vmfle
-| 011010 |V|X| | vmsltu     | 011010 |V| | vmor        | 011010 |V|F| vmford
+| 011010 |V|X| | vmsltu     | 011010 |V| | vmor        | 011010 | | |
 | 011011 |V|X| | vmslt      | 011011 |V| | vmxor       | 011011 |V|F| vmflt
 | 011100 |V|X|I| vmsleu     | 011100 |V| | vmornot     | 011100 |V|F| vmfne
 | 011101 |V|X|I| vmsle      | 011101 |V| | vmnand      | 011101 | |F| vmfgt

--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -3159,6 +3159,10 @@ operation exception only on signaling NaN inputs.  `vmflt`, `vmfle`, `vmfgt`,
 and `vmfge` raise the invalid operation exception on both signaling and
 quiet NaN inputs.
 
+For all comparison instructions, an illegal instruction exception is raised if
+the destination vector register overlaps a source vector register group and
+LMUL > 1.
+
 ----
     # Compare equal
     vmfeq.vv vd, vs2, vs1, vm  # Vector-vector
@@ -3203,26 +3207,18 @@ f      scalar floating-point register
 NOTE: Providing all forms is necessary to correctly handle unordered
 comparisons for NaNs.
 
-To help implement the C99 floating-point comparison functions, a
-`vmford` instruction is added that sets a mask register if the
-arguments are ordered (i.e., neither argument is NaN).
-`vmford` raises the invalid operation exception on signaling NaNs only.
-
-----
-    # Are args ordered?
-    vmford.vv  vd, vs2, vs1, vm   # Vector-vector
-    vmford.vf  vd, vs2, rs1, vm   # Vector-scalar
-----
+NOTE: C99 floating-point quiet comparisons can be implemented by masking
+the signaling comparisons when either input is NaN, as follows.  When
+the comparand is a non-NaN constant, the middle two instructions can be
+omitted.
 
 ----
     # Example of implementing isgreater()
-    vmford.vv v0, va, vb       # Only set where args are ordered,
-    vmfgt.vv v0, va, vb, v0.t  # so only set flags on ordered values.
+    vfeq.vv v0, va, va         # Only set where A is not NaN.
+    vfeq.vv v1, vb, vb         # Only set where B is not NaN.
+    vmand.mm v0, v0, v1        # Only set where A and B are ordered,
+    vmfgt.vv v0, va, vb, v0.t  #  so only set flags on ordered values.
 ----
-
-For all comparison instructions, an illegal instruction exception is raised if
-the destination vector register overlaps a source vector register group and
-LMUL > 1.
 
 === Vector Floating-Point Classify Instruction
 


### PR DESCRIPTION
@jhauser-us's survey of the C math library functions concluded that vmford
will not have sufficient impact on performance to justify including.  Many
of the quiet comparisons are against a constant, in which case it does not
help.  For the remaining ones, the penalty is only 1-2 instructions,
depending on whether signaling NaNs are supported.  While signaling NaNs
are supported within the C library itself, GCC's default is to not support
them, so compiled code incurs only a one-instruction penalty for lacking
the vmford instruction.