### PR TITLE
vslideup and vslide1up can overlap the mask register when LMUL=1

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -4005,12 +4005,11 @@ unsigned 5-bit quantity.
 ----
 
 The destination vector register group for `vslideup` cannot overlap
-the vector register group of the source, and if operation is masked
-cannot overlap the vector mask register, otherwise an illegal
+the vector register group of the source, otherwise an illegal
 instruction exception is raised.
 
-NOTE: The non-overlap constraints are to avoid WAR hazards on the
-input vectors during execution, and to enable restart with non-zero
+NOTE: The non-overlap constraint avoids WAR hazards on the
+input vectors during execution, and enables restart with non-zero
 `vstart`.
 
 ==== Vector Slidedown Instructions
@@ -4080,9 +4079,8 @@ elements are zeroed.
 ----
 
 The `vslide1up` instruction requires that the destination vector
-register group does not overlap the source vector register group and
-the mask register if masked.  Otherwise, an illegal instruction
-exception is raised.
+register group does not overlap the source vector register group.
+Otherwise, an illegal instruction exception is raised.
 
 ==== Vector Slide1down Instruction
 


### PR DESCRIPTION
Output element i is masked by mask element i, so there are no WAR hazards on the mask register when LMUL=1.

(The Vector Masking section states the weaker LMUL > 1 constraint, so this PR only deletes text.)

Closes #267