### PR TITLE
Add note that scalar regs are updated even when vstart >= vl

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -264,6 +264,9 @@ no elements are updated in any destination vector register group.
 NOTE: As a consequence, when `vl`=0, no elements are updated in the
 destination vector register group, regardless of `vstart`.
 
+NOTE: Instructions that write a scalar integer or floating-point register
+do so even when `vstart` {ge} `vl`.
+
 NOTE: The number of bits implemented in `vl` depends on the
 implementation's maximum vector length of the smallest supported
 type. The smallest vector implementation, RV32IV, would need at least


### PR DESCRIPTION
Resolves #284