### PR TITLE
Swap opcodes of vwmaccsu and vwmaccus

### DIFF
--- a/inst-table.adoc
+++ b/inst-table.adoc
@@ -94,8 +94,8 @@
 | 111011 | | | |            | 111011 |V|X| vwmul       | 111011 | | |
 | 111100 |V|X| | vwsmaccu   | 111100 |V|X| vwmaccu     | 111100 |V|F| vfwmacc
 | 111101 |V|X| | vwsmacc    | 111101 |V|X| vwmacc      | 111101 |V|F| vfwnmacc
-| 111110 |V|X| | vwsmaccsu  | 111110 |V|X| vwmaccsu    | 111110 |V|F| vfwmsac
-| 111111 | |X| | vwsmaccus  | 111111 | |X| vwmaccus    | 111111 |V|F| vfwnmsac
+| 111110 |V|X| | vwsmaccus  | 111110 |V|X| vwmaccus    | 111110 |V|F| vfwmsac
+| 111111 | |X| | vwsmaccsu  | 111111 | |X| vwmaccsu    | 111111 |V|F| vfwnmsac
 |===
 
 <<<


### PR DESCRIPTION
This makes the opcodes consistent with vwmulsu and vmulhsu, in that xxxx10 means vs2 is signed and vs1 is unsigned.