### PR TITLE
Update README.md to include riscvOVPsim

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ For the most recent stable release, v0.7.1, click [here](https://github.com/risc
 The corresponding Binutils port is [here](https://github.com/sifive/riscv-binutils-gdb/tree/2ce33d5584b11454ee2eb250a679888c310c5d18),
 and the Spike simulator port is [here](https://github.com/riscv/riscv-isa-sim/tree/49eb5a544864e063975af994f8efe3604b4980ae).
 
+The free riscvOVPsim reference simulator from Imperas is available [here on GitHub](https://github.com/riscv/riscv-ovpsim). It is a complete envelope model simulator that covers the full RISC-V specification including the base Vector Extension. It supports all versions of the Vector specification covering the last 12 months and has command line options to select specific versions. It tracks the latest draft specs within about a week of the specs release.
+
 The top level file is [v-spec.adoc](./v-spec.adoc)
 
 Simply clicking on the file in the github repo viewer will render a usable


### PR DESCRIPTION
riscvOVPsim is updated and made available on GitHub very soon after each checkin of the vector spec and is available to all to explore how RISC-V vectors work - I  updated the readme so people are aware of the simulator to help them explore vectors.