### PR TITLE
Add overlap constraint for segment load destination and mask register

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -1692,6 +1692,13 @@ There are also fault-only-first versions of the unit-stride instructions.
     vlseg<nf>eff.v vd, (rs1),  vm          # Unit-stride fault-only-first segment loads
 ----
 
+For unit-stride segment loads, the destination vector register groups
+cannot overlap the mask register if masked, else an illegal instruction
+exception is raised.
+
+NOTE: This constraint supports restart of segment loads
+that raise exceptions partway through loading a structure.
+
 ==== Vector Strided Segment Loads and Stores
 
 Vector strided segment loads and stores move contiguous segments where
@@ -1720,6 +1727,13 @@ NOTE: Negative and zero strides are supported.
 For strided segment stores where the byte stride is such that segments
 could overlap in memory, the segments must appear to be written in
 element order.
+
+For strided segment loads, the destination vector register groups
+cannot overlap the mask register if masked, else an illegal instruction
+exception is raised.
+
+NOTE: This constraint supports restart of strided segment loads
+that raise exceptions partway through loading a structure.
 
 ==== Vector Indexed Segment Loads and Stores
 


### PR DESCRIPTION
If an exception occurs partway through loading a segment, and the mask
register has been overwritten, restarting the load is problematic.

It seems we already came to this conclusion once, beacuse this constraint
exists for indexed segment loads.  The constraint seems to apply equally
to the other classes of segment load, though.