### PR TITLE
Allow ELEN < max(XLEN, FLEN).

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -176,7 +176,7 @@ encoding.
 The value in `vsew` sets the dynamic _standard_ _element_ _width_
 (SEW).  By default, a vector register is viewed as being divided into
 VLEN / SEW standard-width elements. The valid SEW values are the powers
-of two from 8 to ELEN.
+of two from 8 to ELEN, inclusive.
 
 .vsew[2:0] (standard element width) encoding
 [cols="1,1,1,>13"]

--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -175,8 +175,8 @@ encoding.
 
 The value in `vsew` sets the dynamic _standard_ _element_ _width_
 (SEW).  By default, a vector register is viewed as being divided into
-VLEN / SEW standard-width elements.  In the base vector extension,
-only SEW up to max(XLEN,FLEN) are required to be supported.
+VLEN / SEW standard-width elements. The valid SEW values are the powers
+of two from 8 to ELEN.
 
 .vsew[2:0] (standard element width) encoding
 [cols="1,1,1,>13"]


### PR DESCRIPTION
The spec says:

> Platform profiles may set further constraints on these parameters, for example, requiring that ELEN ≥ max(XLEN,FLEN),

but then below,

> In the base vector extension, only SEW up to max(XLEN,FLEN) are required to be supported.

Since ELEN >= SEW, this seems to mandate that ELEN >= max(XLEN,FLEN).

This PR relaxes this requirement while clarifying the (previously implicit) constraint that SEW must be a power of two between 8 and ELEN (inclusive). This closes #404.

