### PR TITLE
slide[1]up can overlap the mask if LMUL=1

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -4090,7 +4090,7 @@ if _OFFSET_ < `vl`.
 ----
 
 The destination vector register group for `vslideup` cannot overlap
-the source vector register group or the mask register, otherwise an
+the source vector register group, otherwise an
 illegal instruction exception is raised.
 
 NOTE: The non-overlap constraint avoids WAR hazards on the
@@ -4163,9 +4163,8 @@ elements are unchanged.
 ----
 
 The `vslide1up` instruction requires that the destination vector
-register group does not overlap the source vector register group or
-the mask register.  Otherwise, an illegal instruction exception is
-raised.
+register group does not overlap the source vector register group.
+Otherwise, an illegal instruction exception is raised.
 
 ==== Vector Slide1down Instruction
 


### PR DESCRIPTION
Resolves #380

I added this to the spec in b853d77d9ca539f669960f35d93eed6da9068c1c but @kasanovic reverted it in 01a1adc5274238f103ee1f622d21e735762f916b without explanation, which I think might have been an accident.

The rationale is that, since _output_ element i is masked by mask element i, there is no intra-instruction WAR hazard.