### PR TITLE
Use funct3=0 for vl<nf>r/vs<nf>r

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -1906,11 +1906,11 @@ Software can determine the number of bytes transferred by reading the
 ----
 Format for Vector Load Whole Register Instructions under LOAD-FP major opcode
 31 29 28 26  25  24      20 19       15 14   12 11      7 6     0
- nf  | 000 | 1 |   01000   |    rs1    |  111  |    vd   |0000111| VL<nf>R
+ nf  | 000 | 1 |   01000   |    rs1    |  000  |    vd   |0000111| VL<nf>R
 
 Format for Vector Store Whole Register Instructions under STORE-FP major opcode
 31 29 28 26  25  24      20 19       15 14   12 11      7 6     0
- nf  | 000 | 1 |   01000   |    rs1    |  111  |   vs3   |0100111| VS<nf>R
+ nf  | 000 | 1 |   01000   |    rs1    |  000  |   vs3   |0100111| VS<nf>R
 ----
 
 


### PR DESCRIPTION
Since they have EEW=8, making their encoding match that of vle8 avoids a special case.