### PR TITLE
Improve calling convention description

### DIFF
--- a/calling-convention.adoc
+++ b/calling-convention.adoc
@@ -2,15 +2,23 @@
 == Calling Convention
 
 In the RISC-V psABI, the vector registers `v0`-`v31` are all caller-saved.
-The `vstart`, `vl`, and `vtype` CSRs are also caller-saved.
+The `vl` and `vtype` CSRs are also caller-saved.
 
-The `vxrm` and `vxsat` fields have thread storage duration.
+Procedures may assume that `vstart` is zero upon entry.  Procedures may
+assume that `vstart` is zero upon return from a procedure call.
 
-Executing a system call causes `v0`-`v31` to become unspecified.
+NOTE: Application software should normally not write `vstart` explicitly.
+Any procedure that does explicitly write `vstart` to a nonzero value must
+zero `vstart` before either returning or calling another procedure.
+
+The `vxrm` and `vxsat` fields of `vcsr` have thread storage duration.
+
+Executing a system call causes all caller-saved vector registers
+(`v0`-`v31`, `vl`, `vtype`) and `vstart` to become unspecified.
 
 NOTE: This scheme allows system calls that cause context switches to avoid
 saving and later restoring the vector registers.
 
-NOTE: The values that `v0`-`v31` assume after a system call cannot expose
-information from other processes, so typically the registers will either
-remain intact or will be zeroed.
+NOTE: Most OSes will choose to either leave these registers intact or reset
+them to their initial state to avoid leaking information across process
+boundaries.


### PR DESCRIPTION
vstart isn't really caller-saved; it's always zero, as far as the calling convention is concerned.