### PR TITLE
updated to reflect v0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # riscv-v-spec
 Working draft of the proposed RISC-V V vector extension.
 
-For the current stable release, v0.8, click [here](https://github.com/riscv/riscv-v-spec/releases/tag/0.8).
+For the current stable release, v0.9, click [here](https://github.com/riscv/riscv-v-spec/releases/tag/0.9).
+
+For the _previous_ stable release, v0.8, click [here](https://github.com/riscv/riscv-v-spec/releases/tag/0.8).
 
 For the _previous_ stable release, v0.7.1, click [here](https://github.com/riscv/riscv-v-spec/releases/tag/0.7.1).
 
@@ -19,16 +21,17 @@ International License. See the LICENSE file for details.
 
 ### Additional Resources
 
+- [riscvOVPsim](https://github.com/riscv/riscv-ovpsim) is a free
+  RISC-V reference simulator that has support for v0.9, v0.8 and
+  v0.7.1 (simulator is under a proprietary license, models are
+  open source)
 - The [Binutils port for v0.8](https://github.com/riscv/riscv-binutils-gdb/tree/rvv-0.8.x)
 - The [GNU toolchain port for v0.8](https://github.com/riscv/riscv-gnu-toolchain/tree/rvv-0.8.x)
 - The [Spike simulator](https://github.com/riscv/riscv-isa-sim) which supports v0.8
 - The [RISC-V Proxy Kernel](https://github.com/riscv/riscv-pk)
   (to be used with e.g. Spike) supports enabling v0.8 CPU support
   when compiled with a v0.8 capable GNU toolchain
-- [riscvOVPsim](https://github.com/riscv/riscv-ovpsim) is a free
-  RISC-V reference simulator that has support for  v0.8 and
-  v0.7.1 (simulator is under a proprietary license, models are
-  open source)
+
 
 ### Documentation generator
 


### PR DESCRIPTION
riscvOVPsim now updated to support v0.9 so put at top of resources as others are only 0.8