### PR TITLE
Fix definition of first-fault loads w.r.t. nonzero vstart

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -1695,8 +1695,8 @@ These instructions execute as a regular load except that they will
 only take a trap caused by a synchronous exception on element 0.  If
 an element > 0 raises an exception, that element and all following
 elements in the destination vector register are not modified, and the
-vector length `vl` is reduced to the number of elements processed
-without a trap.
+vector length `vl` is reduced to the index of the element that would
+have raised an exception.
 
 ----
     # Vector unit-stride fault-only-first loads and stores


### PR DESCRIPTION
The old definition ("vl is reduced to the number of elements processed")
is only true when vstart=0, since elements [0, vstart-1] are not processed.