### PR TITLE
Update strcpy and strncpy example.

### DIFF
--- a/example/strcpy.s
+++ b/example/strcpy.s
@@ -6,14 +6,14 @@ strcpy:
       mv a2, a0             # Copy dst
       li t0, -1             # Infinite AVL
 loop:
-    vsetvli x0, t0, e8, m8, ta,ma  # Max length vectors of bytes
+    vsetvli x0, t0, e8, m8, ta, ma # Max length vectors of bytes
     vle8ff.v v8, (a1)        # Get src bytes
       csrr t1, vl           # Get number of bytes fetched
     vmseq.vi v1, v8, 0      # Flag zero bytes
     vfirst.m a3, v1         # Zero found?
       add a1, a1, t1        # Bump pointer
-    vmsif.m v0, v1          # Set mask up to and including zero byte.
-    vse8.v v8, (a2), v0.t    # Write out bytes
+    vsetvli x0, a3, e8, m8, ta, ma # Setup vl including zero byte.
+    vse8.v v8, (a2)          # Write out bytes
       add a2, a2, t1        # Bump pointer
       bltz a3, loop         # Zero byte not found, so loop
 

--- a/example/strncpy.s
+++ b/example/strncpy.s
@@ -5,13 +5,13 @@
 strncpy:
       mv a3, a0             # Copy dst
 loop:
-    vsetvli x0, a2, e8,m8, ta,ma   # Vectors of bytes.
+    vsetvli x0, a2, e8, m8, ta, ma # Vectors of bytes.
     vle8ff.v v8, (a1)        # Get src bytes
     vmseq.vi v1, v8, 0      # Flag zero bytes
       csrr t1, vl           # Get number of bytes fetched
     vfirst.m a4, v1         # Zero found?
-    vmsif.m v0, v1          # Set mask up to and including zero byte.
-    vse8.v v8, (a3), v0.t    # Write out bytes
+    vsetvli x0, a4, e8, m8, ta, ma # Setup vl including zero byte.
+    vse8.v v8, (a3)          # Write out bytes
       sub a2, a2, t1        # Decrement count.
       bgez a4, zero_tail    # Zero remaining bytes.
       add a1, a1, t1        # Bump pointer
@@ -21,11 +21,11 @@ loop:
       ret
 
 zero_tail:
-    vsetvli x0, a2, e8,m8,ta,ma   # Vectors of bytes.
+    vsetvli x0, a2, e8, m8, ta, ma # Vectors of bytes.
     vmv.v.i v0, 0           # Splat zero.
 
 zero_loop:
-    vsetvli t1, a2, e8,m8,ta,ma   # Vectors of bytes.
+    vsetvli t1, a2, e8, m8, ta, ma # Vectors of bytes.
     vse8.v v0, (a3)          # Store zero.
       sub a2, a2, t1        # Decrement count.
       add a3, a3, t1        # Bump pointer


### PR DESCRIPTION
1. skip the "vmsif" instruction.
2. update the indent for "vsetvli" instruction.