### PR TITLE
Add assembly pseudoinstructions: vfabs.v

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -64,7 +64,7 @@ profiles can still mandate a minimum ELEN when LMUL = 1.
 
 === Moved quad-widening mulacc to appendix and removed instruction encodings to make clear not part of v1.0
 
-=== Added `vneg` and `vfneg` pseudo-instructions.
+=== Added `vfabs`, `vneg` and `vfneg` pseudo-instructions.
 
 :sectnums:
 
@@ -3749,6 +3749,11 @@ NOTE: A vector of floating-point values can be negated using a
 sign-injection instruction with both source operands set to the same
 vector operand.  Can define assembly pseudoinstruction `vfneg.v vd,vs`
 = `vfsgnjn.vv vd,vs,vs`.
+
+NOTE: A vector of floating-point values can take absolute value using a
+sign-injection instruction with both source operands set to the same
+vector operand.  Can define assembly pseudoinstruction `vfabs.v vd,vs`
+= `vfsgnjx.vv vd,vs,vs`.
 
 === Vector Floating-Point Compare Instructions
 


### PR DESCRIPTION
Reviewed all pseudo instructions for scalar instruction[1], and found fabs are missing for vector.

[1] https://github.com/riscv/riscv-asm-manual/blob/master/riscv-asm.md#a-listing-of-standard-risc-v-pseudoinstructions