### PR TITLE
Rename vncvt.x.x.v to vncvt.x.x.w

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -50,7 +50,7 @@ profiles can still mandate a minimum ELEN when LMUL = 1.
 
 === Defined interaction of `misa.v` and `mstatus.vs`
 
-=== Defined integer narrowing pseudo-instruction `vncvt.x.x.v vd,vs,vm`
+=== Defined integer narrowing pseudo-instruction `vncvt.x.x.w vd,vs,vm`
 
 === Added reciprocal and reciprocal square-root estimate instructions
 
@@ -2847,7 +2847,7 @@ destination is 1/4 width of source.
 
 NOTE: An integer value can be halved in width using the narrowing integer
 shift instructions with a scalar operand of x0. Can define assembly
-pseudoinstructions `vncvt.x.x.v vd,vs,vm` = `vnsrl.wx vd,vs,x0,vm`.
+pseudoinstructions `vncvt.x.x.w vd,vs,vm` = `vnsrl.wx vd,vs,x0,vm`.
 
 === Vector Integer Comparison Instructions
 


### PR DESCRIPTION
 - Make the naming rule consistent with vfncvt.x.f.w.