### PR TITLE
Fix bug in example with mixed-width mask & compute 

### DIFF
--- a/vector-examples.adoc
+++ b/vector-examples.adoc
@@ -24,7 +24,7 @@ include::example/vvaddint32.s[lines=4..-1]
       add a1, a1, a4              # Bump pointer.
     vmslt.vi v0, v1, 5            # a[i] < 5?
 
-    vsetvli x0, x0, e32,m4.ta,mu  # Vector of 32-bit values.
+    vsetvli x0, x0, e32,m4,ta,mu  # Vector of 32-bit values.
       sub a0, a0, a4              # Decrement count
     vmv.v.i v4, 1                 # Splat immediate to destination
     vle32.v v4, (a3), v0.t        # Load requested elements of C, others undisturbed

--- a/vector-examples.adoc
+++ b/vector-examples.adoc
@@ -53,8 +53,8 @@ loop:
       sub a0, a0, t0        # Decrement element count
       add a1, a1, t0        # x[i] Bump pointer
     vmslt.vi v0, v0, 5      # Set mask in v0
-      slli t0, t0, 1        # Multiply by 2 bytes
     vsetvli t0, a0, e16,m2,ta,mu  # Use 16b elements.
+      slli t0, t0, 1        # Multiply by 2 bytes
     vle16.v v1, (a2), v0.t  # z[i] = a[i] case
     vmnot.m v0, v0          # Invert v0
       add a2, a2, t0        # a[i] bump pointer

--- a/vector-examples.adoc
+++ b/vector-examples.adoc
@@ -24,7 +24,7 @@ include::example/vvaddint32.s[lines=4..-1]
       add a1, a1, a4              # Bump pointer.
     vmslt.vi v0, v1, 5            # a[i] < 5?
 
-    vsetvli x0, a0, e32,m4.ta,mu  # Vector of 32-bit values.
+    vsetvli x0, x0, e32,m4.ta,mu  # Vector of 32-bit values.
       sub a0, a0, a4              # Decrement count
     vmv.v.i v4, 1                 # Splat immediate to destination
     vle32.v v4, (a3), v0.t        # Load requested elements of C, others undisturbed


### PR DESCRIPTION
I guess this line of code should change the vtype without overwriting the register x0. 