### PR TITLE
Relax whole-register load/store alignment constraints again

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -2082,9 +2082,9 @@ The instructions operate similarly to unmasked unit-stride load and
 store instructions of elements, with the base address passed in the
 scalar `x` register specified by `rs1`.
 
-Implementations are allowed to raise a misaligned address exception if
-the base address is not naturally aligned to the smallest supported
-SEW, even if this is larger than 8.
+Implementations are allowed to raise a misaligned address exception if the
+base address, in bits, is not naturally aligned to the lesser of XLEN and
+the greatest supported SEW.
 
 NOTE: Allowing misaligned exceptions to be raised simplifies the
 implementation of these instructions.  Some implementations might not


### PR DESCRIPTION
6dc34f62072a95a4ca1d6dc8d8b43ace731b21ce made what I think was an unintentional change: that the alignment requirement for whole-register loads and stores is min-SEW.  When EEW > min-SEW, this is stricter on implementations than the previous definition, which allowed implementations to require EEW alignment.  The alignment requirement should be on max(EEW, min-SEW).