### PR TITLE
Reintroduce fractional LMUL SEW constraint

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -345,6 +345,9 @@ supported SEW value at LMUL=1 and SEW~LMUL1MAX~ is the widest
 supported SEW value at LMUL=1.  An attempt to set an unsupported SEW
 and LMUL configuration sets the `vill` bit in `vtype`.
 
+For a given supported fractional LMUL, implementations must support SEW
+settings between SEW~LMUL1MIN~ and LMUL * SEW~LMUL1MAX~, inclusive.
+
 NOTE: Requiring LMUL {ge} SEW~LMUL1MIN~/SEW~LMUL1MAX~ allows software
 operating on mixed-width elements to only use a single vector register
 to hold the wider elements, with fractional


### PR DESCRIPTION
Commit 7088c9e7 inadvertently changed the constraints for implementations that have SEW_LMUL1MAX_ == SEW_LMUL1MIN_.  The previous expression of the constraint, LMUL >= SEW/ELEN, implicitly (but perhaps esoterically) permitted the set of valid SEWs to vary with the current LMUL setting.  In particular, it was previously valid to set vill when LMUL * ELEN < SEW: e.g., ELEN=64 machines were allowed to reject e16,mf8.

This commit undoes the unintentional change; i.e., it reintroduces the idea that the set of valid SEWs may decrease as fractional LMUL decreases.