### PR TITLE
Mapping for frac lmul

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -797,7 +797,7 @@ least-significant byte of the stored element.
 
 When LMUL < 1, only the first LMUL*VLEN/SEW elements in the vector
 register are used.  The remaining space in the vector register is
-treated as part of the tail.
+treated as part of the tail, and hence must obey the vta setting.
 
 ----
  Example, VLEN=128b, LMUL=1/4


### PR DESCRIPTION
In the frac lmul section, remind reader that tail elements must obey vta