### PR TITLE
Note for readers on vl setting for VLMAX < AVL < 2*VLMAX

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -1447,6 +1447,7 @@ loops uses the largest vector length of all iterations, even in the case
 of `AVL < 2*VLMAX`.
 This allows software to avoid needing to explicitly calculate a running
 maximum of vector lengths observed during a stripmined loop.
+Requirement 2 also allows an implementation to set vl to VLMAX for `VLMAX < AVL < 2*VLMAX` 
 --
 
 [[example-stripmine-sew]]


### PR DESCRIPTION
Helping readers realize that the equation allows for a simpler choice of just using VLMAX in this case