### PR TITLE
Fix wrong expansion for masked vmsge{u}.vx with temp register

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -3125,15 +3125,10 @@ masked va >= x, vd != v0
   pseudoinstruction: vmsge{u}.vx vd, va, x, v0.t
   expansion: vmslt{u}.vx vd, va, x, v0.t; vmxor.mm vd, vd, v0
 
-masked va >= x, vd == v0
-
-  pseudoinstruction: vmsge{u}.vx vd, va, x, v0.t, vt
-  expansion: vmslt{u}.vx vt, va, x;  vmandnot.mm vd, vd, vt
-
 masked va >= x, any vd
 
   pseudoinstruction: vmsge{u}.vx vd, va, x, v0.t, vt
-  expansion: vmslt{u}.vx vt, va, x;  vmandnot.mm vt, v0, vt;  vmandnot.mm vd, vd, v0;  vmor.mm vd, vt, vd
+  expansion: vmslt{u}.vx vt, va, x;  vmandnot.mm vd, v0, vt
 
   The vt argument to the pseudoinstruction must name a temporary vector register that is
   not same as vd and which will be clobbered by the pseudoinstruction


### PR DESCRIPTION
The register 'vd' is unknown value in the instruction context,
and we could merge condition 'masked va >= x, vd == v0' and 'masked va >= x, any vd'