### PR TITLE
Fix incorrect statement about vasub overflow

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -3423,8 +3423,11 @@ vssub.vx vd, vs2, rs1, vm   # vector-scalar
 The averaging add and subtract instructions right shift the result by
 one bit and round off the result according to the setting in `vxrm`.
 Both unsigned and signed versions are provided.
-For `vaaddu`, `vaadd`, and `vasub`, there can be no overflow in the result.
-For `vasubu`, overflow is ignored and the result wraps around.
+For `vaaddu` and `vaadd` there can be no overflow in the result.
+For `vasub` and `vasubu`, overflow is ignored and the result wraps around.
+
+NOTE: For `vasub`, overflow occurs only when subtracting the smallest number
+from the largest number under `rnu` or `rne` rounding.
 
 ----
 # Averaging add


### PR DESCRIPTION
It's true that vasub can never overflow when rounding down or jamming, but when rounding to nearest and using the most extreme operands, overflow _can_ occur.