### PR TITLE
Clarify that whole-register loads do use the encoded EEW

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -29,6 +29,8 @@ Alex Solomatnikov, Steve Wallach, Andrew Waterman, Jim Wilson.
 
 === Specified that fault-only-first segment load instructions may update destination registers past the point that trimming occurs.
 
+=== Removed contradictory text in whole-register load section that implied that EEW is always 8, regardless of the EEW encoded in the opcode.
+
 :sectnums:
 
 == Introduction

--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -2121,20 +2121,15 @@ handlers, and OS context switches.  Software can determine the number
 of bytes transferred by reading the `vlenb` register.
 
 The load instructions have an EEW encoded in the `mew` and `width`
-fields following the pattern of regular unit-stride loads.  Because
-in-register byte layouts are identical to in-memory byte layouts,
-these instructions all operate the same as moving vectors of bytes
-with EEW=8, regardless of actual EEW encoding.  Pseudoinstructions
-are provided for whole register load instructions that correspond to
-EEW=8.
+fields following the pattern of regular unit-stride loads.
 
-NOTE: For the purposes of opaque save and restore of register state,
-the instructions have been defined as only moving byte vectors (SEW=8)
-between registers and memory.
-
-NOTE: The encoded EEW can be used as a HINT to indicate the
-destination register group will next be accessed with this EEW, which
-aids implementations that rearrange data internally.
+NOTE: Because in-register byte layouts are identical to in-memory byte
+layouts, the same data is written to the destination register group
+regardless of EEW.
+Hence, it would have sufficed to provide only EEW=8 variants.
+The full set of EEW variants is provided so that the encoded EEW can be used
+as a hint to indicate the destination register group will next be accessed
+with this EEW, which aids implementations that rearrange data internally.
 
 The vector whole register store instructions are encoded similar to
 unmasked unit-stride store of elements with EEW=8.
@@ -2229,10 +2224,6 @@ an ABI.  The base V extension mandates support for SEW=8.
 
 NOTE: Implementations should raise illegal instruction exceptions on
 `vl<nf>r` instructions for EEW values that are not supported.
-
-NOTE: These instructions can be implemented as unit-stride
-loads/stores of vector register groups, where EEW is 8, `nf` encodes
-EMUL, and `vl` = VLMAX for EEW and EMUL.
 
 NOTE: We have considered adding a whole register mask load
 instruction (``vl1re1.v vd, (rs1)``), with EEW=1, as a mask hint but this is not currently on


### PR DESCRIPTION
The old text points out that, because the in-memory layout and in-register layouts are the same, the instructions behave the same as moving vectors of bytes with EEW=8.  True enough as far as the data transfer, but not so for the handling of evl/vstart: those actually do depend on the encoded EEW.

This choice is consistent with the later statement that "implementations are allowed to raise a misaligned address exception on whole register loads", meaning (a) that EEW is not truly a HINT and (b) the unit of transfer really is elements, not bytes, even if the effect of a successful transfer is the same.

Fix by rewriting misleading text and moving it to non-normative.