### PR TITLE
Add space between VType's operands

### DIFF
--- a/ediv.adoc
+++ b/ediv.adoc
@@ -46,7 +46,7 @@ the EDIV options.
  d4   # EDIV 4
  d8   # EDIV 8
 
- vsetvli t0, a0, e32,m2,d4   # SEW=32, LMUL=2, EDIV=4
+ vsetvli t0, a0, e32, m2, d4   # SEW=32, LMUL=2, EDIV=4
 ----
 
 |===
@@ -121,7 +121,7 @@ elements with a `vl` of 5 and EDIV of 4, operates identically to a
 vector add of 8-bit elements with a vector length of 20.
 
 ----
-vsetvli t0, a0, e32,m1,d4  # Vectors of 32-bit elements, divided into byte sub-elements
+vsetvli t0, a0, e32, m1, d4  # Vectors of 32-bit elements, divided into byte sub-elements
 vadd.vv v1,v2,v3                     # Performs a vector of 4*vl 8-bit additions.
 vsll.vx v1,v2,x1                     # Performs a vector of 4*vl 8-bit shifts.
 ----
@@ -146,7 +146,7 @@ equal to the element size).
 
 ----
 # Sum each sub-vector of four bytes into a 16-bit result.
-vsetvli t0, a0, e32,d4  # Vectors of 32-bit elements, divided into byte sub-elements
+vsetvli t0, a0, e32, d4  # Vectors of 32-bit elements, divided into byte sub-elements
 vwredsum.vs v1, v2, v3 # v1[i][15:0] = v2[i][31:24] + v2[i][23:16]
                        #              + v2[i][15:8] + v2[i][7:0] + v3[i][15:0]
 
@@ -247,11 +247,11 @@ vfdot.vv  vd, vs2, vs1, vm # vd[i][31:0] += vs2[i][31:16] * vs1[i][31:16]
                                            + vs2[i][15:0] * vs1[i][15:0]
 
 # Floating-point sub-vectors of two half-precision floats packed into 32-bit elements.
-vsetvli t0, a0, e32,m1,d2  # Vectors of 32-bit elements, divided into 16b sub-elements
+vsetvli t0, a0, e32, m1, d2  # Vectors of 32-bit elements, divided into 16b sub-elements
 vfdot.vv v1, v2, v3   # v1[i][31:0] +=  v2[i][31:16]*v3[i][31:16] + v2[i][16:0]*v3[i][16:0]
 
 # Floating-point sub-vectors of four half-precision floats packed into 64-bit elements.
-vsetvli t0, a0, e64,m1,d4  # Vectors of 64-bit elements, divided into 16b sub-elements
+vsetvli t0, a0, e64, m1, d4  # Vectors of 64-bit elements, divided into 16b sub-elements
 vfdot.vv v1, v2, v3
                  # v1[i][31:0] +=  v2[i][31:16]*v3[i][31:16] + v2[i][16:0]*v3[i][16:0] +
                  #                 v2[i][63:48]*v3[i][63:48] + v2[i][47:32]*v3[i][47:32];

--- a/example/memcpy.s
+++ b/example/memcpy.s
@@ -7,7 +7,7 @@
   memcpy:
       mv a3, a0 # Copy destination
   loop:
-    vsetvli t0, a2, e8,m8,ta,ma   # Vectors of 8b
+    vsetvli t0, a2, e8, m8, ta, ma   # Vectors of 8b
     vle8.v v0, (a1)               # Load bytes
       add a1, a1, t0              # Bump pointer
       sub a2, a2, t0              # Decrement count

--- a/example/saxpy.s
+++ b/example/saxpy.s
@@ -16,7 +16,7 @@
 #     a2      y
 
 saxpy:
-    vsetvli a4, a0, e32, m8, ta,ma
+    vsetvli a4, a0, e32, m8, ta, ma
     vle32.v v0, (a1)
     sub a0, a0, a4
     slli a4, a4, 2

--- a/example/strcpy.s
+++ b/example/strcpy.s
@@ -6,7 +6,7 @@ strcpy:
       mv a2, a0             # Copy dst
       li t0, -1             # Infinite AVL
 loop:
-    vsetvli x0, t0, e8, m8, ta,ma  # Max length vectors of bytes
+    vsetvli x0, t0, e8, m8, ta, ma  # Max length vectors of bytes
     vle8ff.v v8, (a1)        # Get src bytes
       csrr t1, vl           # Get number of bytes fetched
     vmseq.vi v1, v8, 0      # Flag zero bytes

--- a/example/strlen.s
+++ b/example/strlen.s
@@ -7,7 +7,7 @@
 strlen:
     mv a3, a0             # Save start
 loop:
-    vsetvli a1, x0, e8,m8, ta,ma  # Vector of bytes of maximum length
+    vsetvli a1, x0, e8, m8, ta, ma  # Vector of bytes of maximum length
     vle8ff.v v8, (a3)      # Load bytes
     csrr a1, vl           # Get bytes read
     vmseq.vi v0, v8, 0    # Set v0[i] where v8[i] = 0

--- a/example/strncpy.s
+++ b/example/strncpy.s
@@ -5,7 +5,7 @@
 strncpy:
       mv a3, a0             # Copy dst
 loop:
-    vsetvli x0, a2, e8,m8, ta,ma   # Vectors of bytes.
+    vsetvli x0, a2, e8, m8, ta, ma   # Vectors of bytes.
     vle8ff.v v8, (a1)        # Get src bytes
     vmseq.vi v1, v8, 0      # Flag zero bytes
       csrr t1, vl           # Get number of bytes fetched
@@ -21,11 +21,11 @@ loop:
       ret
 
 zero_tail:
-    vsetvli x0, a2, e8,m8,ta,ma   # Vectors of bytes.
+    vsetvli x0, a2, e8, m8, ta, ma   # Vectors of bytes.
     vmv.v.i v0, 0           # Splat zero.
 
 zero_loop:
-    vsetvli t1, a2, e8,m8,ta,ma   # Vectors of bytes.
+    vsetvli t1, a2, e8, m8, ta, ma   # Vectors of bytes.
     vse8.v v0, (a3)          # Store zero.
       sub a2, a2, t1        # Decrement count.
       add a3, a3, t1        # Bump pointer

--- a/example/vvaddint32.s
+++ b/example/vvaddint32.s
@@ -8,7 +8,7 @@
     # a0 = n, a1 = x, a2 = y, a3 = z
     # Non-vector instructions are indented
 vvaddint32:
-    vsetvli t0, a0, e32, ta,ma  # Set vector length based on 32-bit vectors
+    vsetvli t0, a0, e32, ta, ma  # Set vector length based on 32-bit vectors
     vle32.v v0, (a1)         # Get first vector
       sub a0, a0, t0         # Decrement number done
       slli t0, t0, 2         # Multiply number done by 4 bytes

--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -405,10 +405,10 @@ The assembly syntax adds two flags to the `vsetvli` instruction:
  ma   # Mask agnostic
  mu   # Mask undisturbed
 
- vsetvli t0, a0, e32,m4,ta,ma   # Tail agnostic, mask agnostic
- vsetvli t0, a0, e32,m4,tu,ma   # Tail undisturbed, mask agnostic
- vsetvli t0, a0, e32,m4,ta,mu   # Tail agnostic, mask undisturbed
- vsetvli t0, a0, e32,m4,tu,mu   # Tail undisturbed, mask undisturbed
+ vsetvli t0, a0, e32, m4, ta, ma   # Tail agnostic, mask agnostic
+ vsetvli t0, a0, e32, m4, tu, ma   # Tail undisturbed, mask agnostic
+ vsetvli t0, a0, e32, m4, ta, mu   # Tail agnostic, mask undisturbed
+ vsetvli t0, a0, e32, m4, tu, mu   # Tail undisturbed, mask undisturbed
 ----
 
 NOTE: To maintain backward compatibility in the short term and reduce
@@ -1237,8 +1237,8 @@ The new `vtype` setting is encoded in the immediate fields of
 
 Examples:
     vsetvli t0, a0, e8          # SEW= 8, LMUL=1
-    vsetvli t0, a0, e8,m2       # SEW= 8, LMUL=2
-    vsetvli t0, a0, e32,mf2     # SEW=32, LMUL=1/2
+    vsetvli t0, a0, e8, m2      # SEW= 8, LMUL=2
+    vsetvli t0, a0, e32, mf2    # SEW=32, LMUL=1/2
 ----
 
 The `vsetvl` variant operates similarly to `vsetvli` except that it
@@ -1358,14 +1358,14 @@ throughput on mixed-width operations in a single loop.
 #  a2 holds the address of the destination array
 
 loop:
-    vsetvli a3, a0, e16,m4,ta,ma  # vtype = 16-bit integer vectors;
-                                  # also update a3 with vl (# of elements this iteration)
+    vsetvli a3, a0, e16, m4, ta, ma  # vtype = 16-bit integer vectors;
+                                     # also update a3 with vl (# of elements this iteration)
     vle16.v v4, (a1)        # Get 16b vector
     slli t1, a3, 1          # Multiply # elements this iteration by 2 bytes/source element
     add a1, a1, t1          # Bump pointer
     vwmul.vx v8, v4, x10    # Widening multiply into 32b in <v8--v15>
 
-    vsetvli x0, x0, e32,m8,ta,ma  # Operate on 32b values
+    vsetvli x0, x0, e32, m8, ta, ma  # Operate on 32b values
     vsrl.vi v8, v8, 3
     vse32.v v8, (a2)        # Store vector of 32b elements
     slli t1, a3, 2          # Multiply # elements this iteration by 4 bytes/destination element
@@ -1921,7 +1921,7 @@ field to be stored in each segment.
 ----
     # Example 1
     # Memory structure holds packed RGB pixels (24-bit data structure, 8bpp)
-    vsetvli a1, t0, e8, ta,ma
+    vsetvli a1, t0, e8, ta, ma
     vlseg3e8.v v8, (a0), vm
     # v8 holds the red pixels
     # v9 holds the green pixels
@@ -1929,7 +1929,7 @@ field to be stored in each segment.
 
     # Example 2
     # Memory structure holds complex values, 32b for real and 32b for imaginary
-    vsetvli a1, t0, e32, ta,ma
+    vsetvli a1, t0, e32, ta, ma
     vlseg2e32.v v8, (a0), vm
     # v8 holds real
     # v9 holds imaginary
@@ -1965,13 +1965,13 @@ NOTE: Negative and zero strides are supported.
     vssseg<nf>e<eew>.v vs3, (rs1), rs2, vm         # Strided segment stores
 
     # Examples
-    vsetvli a1, t0, e8, ta,ma
+    vsetvli a1, t0, e8, ta, ma
     vlsseg3e8.v v4, (x5), x6   # Load bytes at addresses x5+i*x6   into v4[i],
                               #  and bytes at addresses x5+i*x6+1 into v5[i],
                               #  and bytes at addresses x5+i*x6+2 into v6[i].
 
     # Examples
-    vsetvli a1, t0, e32, ta,ma
+    vsetvli a1, t0, e32, ta, ma
     vssseg2e32.v v2, (x5), x6   # Store words from v2[i] to address x5+i*x6
                                 #   and words from v3[i] to address x5+i*x6+4
 ----
@@ -2002,13 +2002,13 @@ EMUL=(EEW/SEW)*LMUL.
     vsoxseg<nf>ei<eew>.v vs3, (rs1), vs2, vm  # Ordered indexed segment stores
 
     # Examples
-    vsetvli a1, t0, e8, ta,ma
+    vsetvli a1, t0, e8, ta, ma
     vluxseg3ei32.v v4, (x5), v3   # Load bytes at addresses x5+v3[i]   into v4[i],
                               #  and bytes at addresses x5+v3[i]+1 into v5[i],
                               #  and bytes at addresses x5+v3[i]+2 into v6[i].
 
     # Examples
-    vsetvli a1, t0, e32, ta,ma
+    vsetvli a1, t0, e32, ta, ma
     vsuxseg2ei32.v v2, (x5), v5   # Store words from v2[i] to address x5+v5[i]
                               #   and words from v3[i] to address x5+v5[i]+4
 ----
@@ -4379,7 +4379,7 @@ instructions (indexed stores) to perform vector compress functions.
 compact_non_zero:
     li a6, 0                      # Clear count of non-zero elements
 loop:
-    vsetvli a5, a0, e32,m8,ta,ma   # 32-bit integers
+    vsetvli a5, a0, e32, m8, ta, ma   # 32-bit integers
     vle32.v v8, (a1)               # Load input vector
       sub a0, a0, a5               # Decrement number done
       slli a5, a5, 2               # Multiply by four bytes

--- a/vector-examples.adoc
+++ b/vector-examples.adoc
@@ -19,12 +19,12 @@ include::example/vvaddint32.s[lines=4..-1]
 #
 # Mixed-width code that keeps SEW/LMUL=8
   loop:
-    vsetvli a4, a0, e8,m1,ta,ma   # Byte vector for predicate calc
+    vsetvli a4, a0, e8, m1, ta, ma   # Byte vector for predicate calc
     vle8.v v1, (a1)               # Load a[i]
       add a1, a1, a4              # Bump pointer.
     vmslt.vi v0, v1, 5            # a[i] < 5?
 
-    vsetvli x0, a0, e32,m4,ta,mu  # Vector of 32-bit values.
+    vsetvli x0, a0, e32, m4, ta, mu  # Vector of 32-bit values.
       sub a0, a0, a4              # Decrement count
     vmv.v.i v4, 1                 # Splat immediate to destination
     vle32.v v4, (a3), v0.t        # Load requested elements of C, others undisturbed
@@ -48,12 +48,12 @@ include::example/memcpy.s[lines=4..-1]
 #
 
 loop:
-    vsetvli t0, a0, e8,m1,ta,ma # Use 8b elements.
+    vsetvli t0, a0, e8, m1, ta, ma # Use 8b elements.
     vle8.v v0, (a1)         # Get x[i]
       sub a0, a0, t0        # Decrement element count
       add a1, a1, t0        # x[i] Bump pointer
     vmslt.vi v0, v0, 5      # Set mask in v0
-    vsetvli t0, a0, e16,m2,ta,mu  # Use 16b elements.
+    vsetvli t0, a0, e16, m2, ta, mu  # Use 16b elements.
       slli t0, t0, 1        # Multiply by 2 bytes
     vle16.v v2, (a2), v0.t  # z[i] = a[i] case
     vmnot.m v0, v0          # Invert v0


### PR DESCRIPTION
It should have spaces between assembly operands for readability.
Comments for example code doesn't be realigned.
I think all of comments alignment can be unified by other commit.
