### PR TITLE
Further relax tail handling for mask logical instructions

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -355,6 +355,10 @@ except for mask load instructions, any element in the tail of a mask
 result can also be written with the value the mask-producing operation
 would have calculated with `vl`=VLMAX.
 
+Furthermore, for mask logical instructions, any element in the tail of the
+result can be written with the value the mask-producing operation would
+have calculated with `vl`=VLEN, SEW=8, and LMUL=8.
+
 NOTE: The agnostic policy was added to accommodate machines with vector
 register renaming, and/or that have deeply temporal vector registers.
 With an undisturbed policy, all elements would have to be read from


### PR DESCRIPTION
This is a generalization of fd4565e18d882d3ad2df8592be81034bafac1b71 in response to @JamesKenneyImperas' comment https://github.com/riscv/riscv-v-spec/commit/fd4565e18d882d3ad2df8592be81034bafac1b71#commitcomment-51940463