### PR TITLE
vstart needs explicit initialization by software at reset

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -606,7 +606,8 @@ remaining bits in `vtype` are zero, and `vl` is set to zero.
 
 The `vstart`, `vxrm`, `vxsat` CSRs can have arbitrary values at reset.
 
-NOTE: The `vstart`, `vxrm`, and `vxsat` fields should be
+NOTE: Most uses of the vector unit will require an initial `vset{i}vl{i}`,
+which will reset `vstart`.  The `vxrm` and `vxsat` fields should be
 reset explicitly in software before use.
 
 The vector registers can have arbitrary values at reset.

--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -606,8 +606,7 @@ remaining bits in `vtype` are zero, and `vl` is set to zero.
 
 The `vstart`, `vxrm`, `vxsat` CSRs can have arbitrary values at reset.
 
-NOTE: Any use of the vector unit will require an initial `vset{i}vl{i}`,
-which will reset `vstart`.  The `vxrm` and `vxsat` fields should be
+NOTE: The `vstart`, `vxrm`, and `vxsat` fields should be
 reset explicitly in software before use.
 
 The vector registers can have arbitrary values at reset.


### PR DESCRIPTION
I believe that the following commentary is incorrect:

> Any use of the vector unit will require an initial `vset{i}vl{i}`,which will reset `vstart`. 

For example, whole-register operations (copies/loads/stores) can be invoked without `vset{i}vl{i}`. Indeed, we (SiFive) have encountered real application codes generated by LLVM (using RVV intrinsics) which do just this.

This PR only affects non-normative text, i.e., it does not change the specification.