### PR TITLE
Fix implementation of strncpy

### DIFF
--- a/example/strncpy.s
+++ b/example/strncpy.s
@@ -13,14 +13,21 @@ loop:
     vmsif.m v0, v1          # Set mask up to and including zero byte.
     vse8.v v8, (a3), v0.t    # Write out bytes
       sub a2, a2, t1        # Decrement count.
-      bgez a4, zero_tail    # Zero remaining bytes.
       add a1, a1, t1        # Bump pointer
       add a3, a3, t1        # Bump pointer
+      bgez a4, zero_tail    # Zero remaining bytes.
       bnez a2, loop         # Anymore?
 
       ret
 
 zero_tail:
+    sub x0, t1, a4          # Get zero tail length
+    add a2, a2, x0          # Recover count by tail length
+    bnez a2, zero_loop_preheader # Set zero if count still positive
+    ret
+
+zero_loop_preheader:
+    sub a3, a3, x0
     vsetvli x0, a2, e8, m8, ta, ma   # Vectors of bytes.
     vmv.v.i v0, 0           # Splat zero.
 


### PR DESCRIPTION
The pointer arithmetics originally exist after the branch instruction. So they
will be omitted when n is greater than length of src, and the setting of zero
tails will not match the real strncmp.