### PR TITLE
vslide unchanged range correction

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -4571,7 +4571,7 @@ If XLEN > SEW, _OFFSET_ is _not_ truncated to SEW bits.
                VLMAX <= i+OFFSET           src[i] = 0
 
   vslidedown behavior for destination element i in slide
-                   0 <=  i < vstart         Unchanged
+                   0 <  i < vstart         Unchanged
               vstart <= i < vl             vd[i] = src[i] if v0.mask[i] enabled
                   vl <= i < VLMAX          Follow tail policy
 

--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -4571,7 +4571,7 @@ If XLEN > SEW, _OFFSET_ is _not_ truncated to SEW bits.
                VLMAX <= i+OFFSET           src[i] = 0
 
   vslidedown behavior for destination element i in slide
-                   0 <  i < vstart         Unchanged
+                   0 <= i < vstart         Unchanged
               vstart <= i < vl             vd[i] = src[i] if v0.mask[i] enabled
                   vl <= i < VLMAX          Follow tail policy
 

--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -4535,7 +4535,7 @@ if _OFFSET_ < `vl`.
 
    OFFSET is amount to slideup, either from x register or a 5-bit immediate
 
-                    0 <  i < max(vstart, OFFSET)  Unchanged
+                    0 <=  i < max(vstart, OFFSET)  Unchanged
   max(vstart, OFFSET) <= i < vl                   vd[i] = vs2[i-OFFSET] if v0.mask[i] enabled
                    vl <= i < VLMAX                Follow tail policy
 ----
@@ -4571,7 +4571,7 @@ If XLEN > SEW, _OFFSET_ is _not_ truncated to SEW bits.
                VLMAX <= i+OFFSET           src[i] = 0
 
   vslidedown behavior for destination element i in slide
-                   0 <  i < vstart         Unchanged
+                   0 <=  i < vstart         Unchanged
               vstart <= i < vl             vd[i] = src[i] if v0.mask[i] enabled
                   vl <= i < VLMAX          Follow tail policy
 


### PR DESCRIPTION
Shouldn't the lower bound for `i` and unchanged behavior be `0` included rather than excluded ?
If OFFSET is 1
```
vd[0] is unchanged
vd[1] is vs2[0] if v0.mask[i] enabled
...
```