### PR TITLE
v[f]slide1down respects the mask policy

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -4647,8 +4647,9 @@ past `vl` are handled according to the current tail policy (Section
 
 The `vslide1down` instruction places the `x` register argument at
 location `vl`-1 in the destination vector register, provided that
-element `vl-1` is active, otherwise the destination element is
-unchanged. If XLEN < SEW, the value is sign-extended to SEW bits.  If
+element `vl-1` is active, otherwise the destination element update
+follows the current mask agnostic/undisturbed policy.
+If XLEN < SEW, the value is sign-extended to SEW bits.  If
 XLEN > SEW, the least-significant bits are copied over and the high
 SEW-XLEN bits are ignored.
 


### PR DESCRIPTION
Due to what appears to be an editing error in 9c83a0176664bb1fd6ba5b58d14cc80a7563868f, the definition of v[f]slide1down wasn't changed to respect the mask agnostic/undisturbed policy for elt. vl-1.  It should've been.

h/t Brandon Wu