### PR TITLE
Add vsetvli to indicate vl and policy in vcompress example.

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -4752,7 +4752,7 @@ elements according to the current tail policy (Section
         1 1 0 1 0 0 1 0 1   v0
         8 7 6 5 4 3 2 1 0   v1
         1 2 3 4 5 6 7 8 9   v2
-
+                                vsetivli     t0, 9, e8, m1, tu, ma
                                 vcompress.vm v2, v1, v0
         1 2 3 4 8 7 5 2 0   v2
 ----


### PR DESCRIPTION
I think it could make reader aware that "The remaining elements of vd are treated as tail elements according to the current tail policy"