### PR TITLE
Fix sqrt approx for smallest subnormal

### DIFF
--- a/vector-examples.adoc
+++ b/vector-examples.adoc
@@ -101,17 +101,19 @@ vfmul.vv v1, v1, v3         # Estimate of v1/v2
 vmfne.vf v0, v1, ft0        #   to avoid div by zero
 vfrsqrt7.v v2, v1, v0.t     # Estimate 1/sqrt(x)
 vmfne.vf v0, v2, ft0, v0.t  # Additionally mask off +inf inputs
-  li t0, 0xbf000000
-  fmv.w.x ft0, t0           # -0.5
-vfmul.vf v3, v1, ft0, v0.t  # -0.5 * x
-vfmul.vv v4, v2, v2, v0.t   # est * est
-  li t0, 0x3fc00000
-vmv.v.x v5, t0, v0.t        # Splat 1.5
-vfmadd.vv v4, v3, v5, v0.t  # 1.5 - 0.5 * x * est * est
-vfmul.vv v1, v1, v4, v0.t   # estimate to 14 bits
-vfmul.vv v4, v1, v1, v0.t   # est * est
-vfmadd.vv v4, v3, v5, v0.t  # 1.5 - 0.5 * x * est * est
-vfmul.vv v1, v1, v4, v0.t   # estimate to 23 bits
+  li t0, 0x40400000
+vmv.v.x v4, t0              # Splat 3.0
+vfmul.vv v3, v1, v2, v0.t   # x * est
+vfnmsub.vv v3, v2, v4, v0.t # - x * est * est + 3
+vfmul.vv v3, v3, v2, v0.t   # est * (-x * est * est + 3)
+  li t0, 0x3f000000
+  fmv.w.x ft0, t0           # 0.5
+vfmul.vf v2, v3, ft0, v0.t  # Estimate to 14 bits
+vfmul.vv v3, v1, v2, v0.t   # x * est
+vfnmsub.vv v3, v2, v4, v0.t # - x * est * est + 3
+vfmul.vv v3, v3, v2, v0.t   # est * (-x * est * est + 3)
+vfmul.vf v2, v3, ft0, v0.t  # Estimate to 23 bits
+vfmul.vv v1, v2, v1, v0.t   # x * 1/sqrt(x)
 ----
 
 === C standard library strcmp example


### PR DESCRIPTION
As @aswaterman mentioned in https://github.com/riscv/riscv-v-spec/issues/793, the previous example for square root approximation fails when the input is the smallest subnormal float.  This PR fixes that case by avoiding the multiplication by `0.5` that produces a NaN, albeit at the cost of an extra multiply per refinement step.