### PR TITLE
Rename vmandnot and vmornot to vmandn and vmorn

### DIFF
--- a/inst-table.adoc
+++ b/inst-table.adoc
@@ -45,11 +45,11 @@
 | 010101 | | | |            | 010101 | | |             | 010101 | | |
 | 010110 | | | |            | 010110 | | |             | 010110 | | |
 | 010111 |V|X|I| vmerge/vmv | 010111 |V| | vcompress   | 010111 | |F| vfmerge/vfmv
-| 011000 |V|X|I| vmseq      | 011000 |V| | vmandnot    | 011000 |V|F| vmfeq
+| 011000 |V|X|I| vmseq      | 011000 |V| | vmandn      | 011000 |V|F| vmfeq
 | 011001 |V|X|I| vmsne      | 011001 |V| | vmand       | 011001 |V|F| vmfle
 | 011010 |V|X| | vmsltu     | 011010 |V| | vmor        | 011010 | | |
 | 011011 |V|X| | vmslt      | 011011 |V| | vmxor       | 011011 |V|F| vmflt
-| 011100 |V|X|I| vmsleu     | 011100 |V| | vmornot     | 011100 |V|F| vmfne
+| 011100 |V|X|I| vmsleu     | 011100 |V| | vmorn       | 011100 |V|F| vmfne
 | 011101 |V|X|I| vmsle      | 011101 |V| | vmnand      | 011101 | |F| vmfgt
 | 011110 | |X|I| vmsgtu     | 011110 |V| | vmnor       | 011110 | | |
 | 011111 | |X|I| vmsgt      | 011111 |V| | vmxnor      | 011111 | |F| vmfge


### PR DESCRIPTION
According to 15.1, `vmandnot` and `vmornot` have been changed to `vmandn` and `vmorn` to
be consistent with the equivalent scalar instructions.