### PR TITLE
Update v-spec.adoc

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -1812,7 +1812,7 @@ segment, _NFIELDS_.
 The EMUL setting must be such that EMUL * NFIELDS {le} 8, otherwise
 the instruction encoding is reserved.
 
-NOTE: The product EMUL * NFIELDS represents the number of underlying
+NOTE: The product ceil(EMUL) * NFIELDS represents the number of underlying
 vector registers that will be touched by a segmented load or store
 instruction.  This constraint makes this total no larger than 1/4 of
 the architectural register file, and the same as for regular


### PR DESCRIPTION
Correction to non-normative text. If EMUL < 1, segmented ld/st act as if it were 1 for purposes of determining the size of the destination register group.

Signed-off-by: Adrian Harris <48252020+aharris-ventana@users.noreply.github.com>