### PR TITLE
Fix description of reserved vstart values

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -559,7 +559,7 @@ setting (8) and the smallest SEW setting (8), so VLMAX_max = 8*VLEN/8
 represent indices from 0 through 255.
 
 The use of `vstart` values greater than the largest element index for
-the current SEW setting is reserved.
+the current `vtype` setting is reserved.
 
 NOTE: It is recommended that implementations trap if `vstart` is out
 of bounds.  It is not required to trap, as a possible future use of


### PR DESCRIPTION
It's not meaningful to restrict vstart values on the basis of SEW alone, as the maximum element index is a function of LMUL, as well.