### PR TITLE
Suggestion for Fixing func7 for vsetvl

### DIFF
--- a/vcfg-format.adoc
+++ b/vcfg-format.adoc
@@ -38,7 +38,7 @@ Formats for Vector Configuration Instructions under OP-V major opcode
   {bits: 3,  name: 7},
   {bits: 5,  name: 'rs1', type: 4},
   {bits: 5,  name: 'rs2', type: 4},
-  {bits: 6,  name: 0x1000},
+  {bits: 6,  name: 0x00},
   {bits: 1,  name: 1},
 ]}
 ```


### PR DESCRIPTION
Signed-off-by: Nicolas Brunie <82109999+nibrunieAtSi5@users.noreply.github.com>

It looks like func7 field (bits: 1 + bits: 6) is too long and does not hold the correct value here