### PR TITLE
Use vtypei instead of zimm in vcfg-format.adoc

### DIFF
--- a/vcfg-format.adoc
+++ b/vcfg-format.adoc
@@ -14,7 +14,7 @@ Formats for Vector Configuration Instructions under OP-V major opcode
   {bits: 5,  name: 'rd', type: 4},
   {bits: 3,  name: 7},
   {bits: 5,  name: 'rs1', type: 4},
-  {bits: 11, name: 'zimm[10:0]', type: 5},
+  {bits: 11, name: 'vtypei[10:0]', type: 5},
   {bits: 1,  name: '0'},
 ]}
 ```
@@ -25,7 +25,7 @@ Formats for Vector Configuration Instructions under OP-V major opcode
   {bits: 5,  name: 'rd', type: 4},
   {bits: 3,  name: 7},
   {bits: 5,  name: 'uimm[4:0]', type: 5},
-  {bits: 10, name: 'zimm[9:0]', type: 5},
+  {bits: 10, name: 'vtypei[9:0]', type: 5},
   {bits: 1, name: '1'},
   {bits: 1,  name: '1'},
 ]}


### PR DESCRIPTION
This matches how the vset(i)vli instructions are defined.

I'm not sure what the 'z' in zimm was meant to convey. The base ISA spec uses nzimm to mean an immediate that can't be zero, but I don't think it ever uses zimm.

Signed-off-by: Craig Topper <craig.topper@gmail.com>