### PR TITLE
Clarify EMUL constraint for indexed segment ops

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -1947,6 +1947,7 @@ with respect to each other.
 The data vector register group has EEW=SEW, EMUL=LMUL, while the index
 vector register group has EEW encoded in the instruction with
 EMUL=(EEW/SEW)*LMUL.
+The EMUL * NFIELDS {le} 8 constraint applies to the data vector register group.
 
 ----
     # Format


### PR DESCRIPTION
Closes #867 .

Another option is to make this clarification earlier. I don't have strong feelings. Someone else is welcome to propose that.