### PR TITLE
Delete non-normative claim that vmv<nr>r.v doesn't depend on vtype

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -493,7 +493,7 @@ checking for illegal values with a branch on the sign bit.
 If the `vill` bit is set, then any attempt to execute a vector instruction
 that depends upon `vtype` will raise an illegal-instruction exception.
 
-NOTE: `vset{i}vl{i}` and whole-register loads, stores, and moves do not depend
+NOTE: `vset{i}vl{i}` and whole-register loads and stores do not depend
 upon `vtype`.
 
 When the `vill` bit is set, the other XLEN-1 bits in `vtype` shall be


### PR DESCRIPTION
The normative text says that vmv&lt;nr&gt;r.v "operates as though EEW=SEW", meaning that it _does_ depend on vtype.

The semantic difference becomes visible through vstart, since vstart is measured in elements; hence, how to set vstart on an interrupt, or interpret vstart upon resumption, depends on vtype.