### PR TITLE
A few minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ International License. See the LICENSE file for details.
 
 Requirements
 
-`node v6+`
+`node v18.16.0+`
 
 **Linux**: install using [nvm](https://github.com/creationix/nvm)
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   },
   "homepage": "https://github.com/riscv/riscv-v-spec#readme",
   "devDependencies": {
-    "datasheet": "^0.6.0"
+    "datasheet": "^1.1.0"
   }
 }

--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -493,7 +493,7 @@ checking for illegal values with a branch on the sign bit.
 If the `vill` bit is set, then any attempt to execute a vector instruction
 that depends upon `vtype` will raise an illegal-instruction exception.
 
-NOTE: `vset{i}vl{i}` and whole-register loads and stores do not depend
+NOTE: `vset{i}vl{i}` and whole register loads and stores do not depend
 upon `vtype`.
 
 When the `vill` bit is set, the other XLEN-1 bits in `vtype` shall be

--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -2087,7 +2087,8 @@ an ABI.
    vl1re16.v   v3, (a0)  # Load v3 with VLEN/16 halfwords held at address in a0
    vl1re32.v   v3, (a0)  # Load v3 with VLEN/32 words held at address in a0
    vl1re64.v   v3, (a0)  # Load v3 with VLEN/64 doublewords held at address in a0
-   vl2r.v v2, (a0)       # Pseudoinstruction equal to vl2re8.v v2, (a0)
+
+   vl2r.v v2, (a0)       # Pseudoinstruction equal to vl2re8.v
 
    vl2re8.v    v2, (a0)  # Load v2-v3 with 2*VLEN/8 bytes from address in a0
    vl2re16.v   v2, (a0)  # Load v2-v3 with 2*VLEN/16 halfwords held at address in a0


### PR DESCRIPTION
This PR makes minor cosmetic changes and updates NodeJS and datasheet.js
requirements to build with `npm run build`. I could not build with Node v6, but
found that Node v18 worked out. Node v20 works fine, too. I also had to run
`npm audit fix --force` (which force-updated `datasheet`) and
`npm rebuild canvas` when switching between Node versions.