### PR TITLE
"Clarify" that vlm/vsm respect vtype.vill

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -1609,6 +1609,9 @@ policy.
 `lumop` and `sumop` encodings.  Since `vlm.v` and `vsm.v` operate as byte loads and stores,
 `vstart` is in units of bytes for these instructions.
 
+NOTE: `vlm.v` and `vsm.v` respect the `vill` field in `vtype`, as
+they depend on `vtype` indirectly through its constraints on `vl`.
+
 NOTE: The previous assembler mnemonics `vle1.v` and `vse1.v` were
 confusing as length was handled differently for these instructions
 versus other element load/store instructions.  To avoid software


### PR DESCRIPTION
The `vlm`/`vsm` instructions are only meant to be used when `vill`=0, since they are designed to spill or fill only the active subset of a mask register, rather than a whole register.

Recently, the argument was made that they don't truly depend on `vtype`, since their behavior does not depend on the `vma`, `vta`, `vsew`, or `vlmul` fields.  However, the instructions are obviously useless when `vill`=1, since `vill`=1 implies `vl`=0, and so the instructions would become NOPs.

My take is that the instructions indirectly depend on `vtype`, since the instructions depend on `vl`, and `vtype` governs the set of values `vl` may assume. It's not clear that my reasoning is ironclad, but I do believe it to be in line with what the spec authors intended.