### PR TITLE
Clarify that compares only AND in the mask if vd == v0

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -2827,7 +2827,7 @@ masked va >= x, any vd
   not same as vd and which will be clobbered by the pseudoinstruction
 ----
 
-Compares effectively AND in the mask under a mask-undisturbed policy e.g,
+Compares effectively AND in the mask under a mask-undisturbed policy if the destination register is `v0`, e.g.,
 
 ----
     # (a < b) && (b < c) in two instructions when mask-undisturbed


### PR DESCRIPTION
This PR clarifies that masked compares AND in the mask only if the destination register is `v0`, as discussed in #900