### PR TITLE
Specification status updates

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -931,7 +931,7 @@ are written to an `x` or `f` register or to element 0 of a vector
 register.  Any vector register can be used to hold a scalar regardless
 of the current LMUL setting.
 
-NOTE: Zfinx ("F in X") is a proposed new ISA extension where
+NOTE: Zfinx ("F in X") is a new ISA extension where
 floating-point instructions take their arguments from the integer
 register file.  The vector extension is also compatible with Zfinx,
 where the Zfinx vector extension has vector-scalar floating-point
@@ -944,7 +944,7 @@ high-performance scalar floating-point design, and provides
 compatibility with the Zfinx ISA option.  Overlaying `f` with `v`
 would provide the advantage of lowering the number of state bits in
 some implementations, but complicates high-performance designs and
-would prevent compatibility with the proposed Zfinx ISA option.
+would prevent compatibility with the Zfinx ISA option.
 
 [[sec-vec-operands]]
 === Vector Operands
@@ -2263,7 +2263,7 @@ type width (which includes when FLEN < SEW) are reserved.
 NOTE: Some instructions _zero_-extend the 5-bit immediate, and denote this
 by naming the immediate `uimm` in the assembly syntax.
 
-NOTE: When adding a vector extension to the proposed Zfinx/Zdinx/Zhinx
+NOTE: When adding a vector extension to the Zfinx/Zdinx/Zhinx
 extensions, floating-point scalar arguments are taken from the `x`
 registers.  NaN-boxing is not supported in these extensions, and so
 the vector floating-point scalar value is produced using the same

--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -4975,8 +4975,8 @@ implementation to support context switching with imprecise traps.
 [[sec-vector-extensions]]
 == Standard Vector Extensions
 
-This section describes the standard vector extensions to be proposed
-for public review.  A set of smaller extensions intended for embedded
+This section describes the standard vector extensions.
+A set of smaller extensions intended for embedded
 use are named with a "Zve" prefix, while a larger vector extension
 designed for application processors is named as a single-letter V
 extension.  A set of vector length extension names with prefix "Zvl"


### PR DESCRIPTION
Since `V/Zve*/Zvl*` and `Zfinx/Zdinx/Zhinx` extensions are ratified, we no longer need the word "proposed" or references to the public review.

But if you know a better sentence describing the list of vector extensions (near line 4978-4979), please notify me (as a non-native speaker, I always have such anxiety).