### PR TITLE
Proposal: Make `Zvfh` to depend on `Zvfhmin` instead of `Zve32f`

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -5196,7 +5196,7 @@ provided.  The floating-point-to-integer narrowing conversions
 (`vfncvt[.rtz].x[u].f.w`) and integer-to-floating-point
 widening conversions (`vfwcvt.f.x[u].v`) become defined when SEW=8.
 
-The Zvfh extension depends on the Zve32f and Zfhmin extensions.
+The Zvfh extension depends on the Zvfhmin and Zfhmin extensions.
 
 NOTE: Requiring basic scalar half-precision support makes Zvfh's
 vector-scalar instructions substantially more useful.


### PR DESCRIPTION
Although that this is functionally equivalent (since `Zvfhmin` depends on `Zve32f`), it makes clearer that `Zvfh` is a strict superset of `Zvfhmin`.

Again, it will not change the contents of both extensions.
But I believe that this change will ease some developers that depend on the expanded ISA string (e.g. after expanding `G` → `IMAFDC_Zicsr_Zifencei`) or similar data structure (like which QEMU uses) because if we need to probe the vector FP16 conversion capability, we just need to probe for the `Zvfhmin` extension, not `Zvfhmin` or `Zvfh`.