### PR TITLE
Clarify slide semantics

### DIFF
--- a/v-spec.adoc
+++ b/v-spec.adoc
@@ -4554,13 +4554,13 @@ Destination elements _OFFSET_ through `vl`-1 are written if unmasked and
 if _OFFSET_ < `vl`.
 
 ----
-   vslideup behavior for destination elements
+   vslideup behavior for destination elements (`vstart` < `vl`)
 
    OFFSET is amount to slideup, either from x register or a 5-bit immediate
 
-                    0 <=  i < max(vstart, OFFSET)  Unchanged
-  max(vstart, OFFSET) <= i < vl                   vd[i] = vs2[i-OFFSET] if v0.mask[i] enabled
-                   vl <= i < VLMAX                Follow tail policy
+                    0 <= i < min(vl, max(vstart, OFFSET))  Unchanged
+  max(vstart, OFFSET) <= i < vl                            vd[i] = vs2[i-OFFSET] if v0.mask[i] enabled
+                   vl <= i < VLMAX                         Follow tail policy
 ----
 
 The destination vector register group for `vslideup` cannot overlap
@@ -4589,11 +4589,11 @@ using an unsigned integer in the `x` register specified by `rs1`, or a
 If XLEN > SEW, _OFFSET_ is _not_ truncated to SEW bits.
 
 ----
-  vslidedown behavior for source elements for element i in slide
+  vslidedown behavior for source elements for element i in slide (`vstart` < `vl`)
                    0 <= i+OFFSET < VLMAX   src[i] = vs2[i+OFFSET]
                VLMAX <= i+OFFSET           src[i] = 0
 
-  vslidedown behavior for destination element i in slide
+  vslidedown behavior for destination element i in slide (`vstart` < `vl`)
                    0 <= i < vstart         Unchanged
               vstart <= i < vl             vd[i] = src[i] if v0.mask[i] enabled
                   vl <= i < VLMAX          Follow tail policy


### PR DESCRIPTION
This PR aims to address some persistent confusion regarding the behavioral descriptions of `vslideup` and `vslidedown`. I do not believe this changes any semantics. 

Earlier, in Section 5.4, the spec states that
> When `vstart` ≥ `vl`, there are no body elements, and no elements are updated in any destination vector register group, including that no tail elements are updated with agnostic values.

The present behavioral descriptions of `vslideup` and `vslidedown` tacitly assume that `vstart < vl`. Without making this assumption, the descriptions could be interpreted as overriding the general behavior. Additionally, the descriptions become ambiguous, with potential overlap between the cases. This PR makes the assumption `vstart < vl` explicit.

However, even after clarifying the assumption `vstart < vl`, there remains a potential ambiguity in the case of `vslideup`: if `vl < OFFSET <= VLMAX`, then the "unchanged" and "follow tail policy" ranges overlap nontrivially. The confusion is resolved by recalling the definition of tail elements in Section 5.4:

> The tail elements during a vector instruction’s execution are the elements past the current vector length setting specified in `vl`. 

This PR sharpens the upper bound on the first ("unchanged") range to remove the overlap and avoid this potential confusion.