### PR TITLE
README needs to reflect that the 1.0 vector spec has been ratified

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Working draft of the proposed RISC-V V vector extension.
 
 [Version 1.0](https://github.com/riscv/riscv-v-spec/releases/tag/v1.0)
-has been frozen and ratified.
+has been frozen and ratified. This repository now represents work towards a future version 2.0.
 
 The _previous_ stable releases are
 [v1.0-rc2](https://github.com/riscv/riscv-v-spec/releases/tag/v1.0-rc2),

--- a/README.md
+++ b/README.md
@@ -2,12 +2,7 @@
 Working draft of the proposed RISC-V V vector extension.
 
 [Version 1.0](https://github.com/riscv/riscv-v-spec/releases/tag/v1.0)
-has been frozen and at this time is undergoing public review.
-Version 1.0 is considered stable enough to begin developing
-toolchains, functional simulators, and implementations, including in
-upstream software projects, and is not expected to have incompatible
-changes except if serious issues are discovered during
-ratification. Once ratified, the spec will be given version 2.0.
+has been frozen and ratified.
 
 The _previous_ stable releases are
 [v1.0-rc2](https://github.com/riscv/riscv-v-spec/releases/tag/v1.0-rc2),


### PR DESCRIPTION

The vector extension 1.0 specification [has been ratified since November 2021](https://wiki.riscv.org/display/HOME/Recently+Ratified+Extensions), yet there is a curiously repeating pattern of people claiming that it isn't and referencing a version 2.0, which is supposed to be the ratified version. ([1](https://youtu.be/PVHoYQCoVd0?t=5163), [2](https://news.ycombinator.com/item?id=39725655))

This very likely goes back to this repo.
From my understanding it hasn't been updated, because this isn't the right place to look for ratified extensions, and more of a development repository.

I for one think that it's very unprofessional to have this repository, which is referenced all over the place, not updated to reflect it's ratification status.

